### PR TITLE
Fix URL to calico path

### DIFF
--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -191,60 +191,32 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       '64': ami-18afc47f
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
     ap-northeast-2:
       '64': ami-93d600fd
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
     ap-south-1:
       '64': ami-dd3442b2
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
     ap-southeast-1:
       '64': ami-87b917e4
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
     ap-southeast-2:
       '64': ami-e6b58e85
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
     ca-central-1:
       '64': ami-7112a015
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
     eu-central-1:
       '64': ami-fe408091
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
     eu-west-1:
       '64': ami-ca80a0b9
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
     eu-west-2:
       '64': ami-ede2e889
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
     sa-east-1:
       '64': ami-e075ed8c
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
     us-east-1:
       '64': ami-9dcfdb8a
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
     us-east-2:
       '64': ami-fcc19b99
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
     us-west-1:
       '64': ami-b05203d0
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
     us-west-2:
       '64': ami-b2d463d2
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
 
 # Resources are the AWS services we want to actually create as part of the Stack
 Resources:
@@ -342,15 +314,14 @@ Resources:
               # (http://docs.projectcalico.org/v2.0/getting-started/kubernetes/installation/hosted/kubeadm/)
               # so pods can communicate
               kubectl apply -f
+            - ' '
             - Fn::Join:
-              - "/"
-              - - Fn::FindInMap:
-                  - RegionMap
-                  - Ref: AWS::Region
-                  - QuickStartS3URL
+              - ''
+              - - 'https://'
                 - Ref: QSS3BucketName
+                - '.s3.amazonaws.com/'
                 - Ref: QSS3KeyPrefix
-                - scripts/calico.yaml
+                - /scripts/calico.yaml
             - "\n"
 
   # This is a CloudWatch alarm https://aws.amazon.com/cloudwatch/


### PR DESCRIPTION
We're hosting it in our own bucket (or whoever else's bucket they override
with), so use <bucket>.s3.amazonaws.com, which appears to route you to the
right region automatically.

Since we're doing that there's no reason to maintain S3 URL's in the region map
AFAICT.  We may need to test more in other regions to make sure.

Signed-off-by: Ken Simon <ninkendo@gmail.com>