### PR TITLE
logs, cleanup, comments

### DIFF
--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -175,62 +175,40 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       '64': ami-18afc47f
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
     ap-northeast-2:
       '64': ami-93d600fd
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
     ap-south-1:
       '64': ami-dd3442b2
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
     ap-southeast-1:
       '64': ami-87b917e4
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
     ap-southeast-2:
       '64': ami-e6b58e85
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
     ca-central-1:
       '64': ami-7112a015
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
     eu-central-1:
       '64': ami-fe408091
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
     eu-west-1:
       '64': ami-ca80a0b9
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
     eu-west-2:
       '64': ami-ede2e889
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
     sa-east-1:
       '64': ami-e075ed8c
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
     us-east-1:
       '64': ami-9dcfdb8a
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
     us-east-2:
       '64': ami-fcc19b99
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
     us-west-1:
       '64': ami-b05203d0
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
     us-west-2:
       '64': ami-b2d463d2
-      Partition: aws
-      QuickStartS3URL: https://s3.amazonaws.com
 
 Resources:
+  KubernetesLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: Heptio-Kubernetes
+      RetentionInDays: 14
+
   K8sMasterInstance:
     Type: AWS::EC2::Instance
     Properties:
@@ -258,64 +236,72 @@ Resources:
         - '64'
       UserData:
         Fn::Base64:
-          # Nested arrays here: Fn::Join takes a first argument of a join
-          # string (in this case ''), and the second argument is the array
-          # itself.
-          Fn::Join:
-          - ''
-          -
-            - |-
-              #!/bin/bash -v
-              # Create directory and file to enable --cloud-provider=aws for kubelet
-              mkdir -p /etc/systemd/system/kubelet.service.d/
-              cat <<EOF > /etc/systemd/system/kubelet.service.d/20-cloud-provider.conf
-              [Service]
-              Environment="KUBELET_EXTRA_ARGS=--cloud-provider=aws"
-              EOF
+          # replacing Fn:Join with Fn:Sub, this should be a more graceful way to handle CFN variable interpolation
+          Fn::Sub: |
+            #!/bin/bash -v
 
-              # Get repository key
-              curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+            # Update package lists
+            apt-get update
 
-              # Append key to sources file
-              cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
-              deb http://apt.kubernetes.io/ kubernetes-xenial main
-              EOF
+            # Install Cloudwatch bootstap tools and dependencies
+            apt-get install -y unzip python-setuptools
+            easy_install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
 
-              # Update package lists
-              apt-get update
+            # Install Cloudwatch Logs
+            mkdir -p /usr/local/aws
+            wget -O /usr/local/aws/awslogs-agent-setup.py https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py
+            chmod +x /usr/local/aws/awslogs-agent-setup.py
+            #TODO: move config file location to quickstart bucket
+            python /usr/local/aws/awslogs-agent-setup.py -n -r ${AWS::Region} -c http://43d3.brandonchav.is/kubernetes-awslogs.conf
 
-              # Install docker if you don't have it already.
-              apt-get install -y docker.io
+            cat <<EOF > /etc/systemd/system/awslogs.service
+            [Service]
+            Type=simple
+            Restart=always
+            KillMode=process
+            TimeoutSec=infinity
+            PIDFile=/var/awslogs/state/awslogs.pid
+            ExecStart=/var/awslogs/bin/awslogs-agent-launcher.sh --start --background --pidfile $PIDFILE --user awslogs --chuid awslogs &
+            EOF
 
-              # Install kubernetes tools
-              apt-get install -y kubelet kubeadm kubectl kubernetes-cni
+            systemctl enable awslogs.service
+            systemctl start awslogs.service
 
-              # reset kubeadm (workaround for kubelet package presence)
-              kubeadm reset
+            # Create directory and file to enable --cloud-provider=aws for kubelet
+            mkdir -p /etc/systemd/system/kubelet.service.d/
+            cat <<EOF > /etc/systemd/system/kubelet.service.d/20-cloud-provider.conf
+            [Service]
+            Environment="KUBELET_EXTRA_ARGS=--cloud-provider=aws"
+            EOF
 
-              # Initialize master node
-              kubeadm init --cloud-provider=aws --token=
+            # Get repository key
+            curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+
+            # Append key to sources file
+            cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
+            deb http://apt.kubernetes.io/ kubernetes-xenial main
+            EOF
+
+            # Install docker if you don't have it already.
+            apt-get install -y docker.io
+
+            # Install kubernetes tools
+            apt-get install -y kubelet kubeadm kubectl kubernetes-cni
+
+            # reset kubeadm (workaround for kubelet package presence)
+            kubeadm reset
+
+            # Initialize master node
+            kubeadm init --cloud-provider=aws --token=${ClusterToken}
 
             # Embed the provided cluster token in the script, (no newline from
             # above since we're using |-)
-            - { Ref: ClusterToken }
-            - "\n"
 
-            - |-
-              # Add-on for network Calico
-              # (http://docs.projectcalico.org/v2.0/getting-started/kubernetes/installation/hosted/kubeadm/)
-              # so pods can communicate
-              kubectl apply -f
-            - Fn::Join:
-              - "/"
-              - - Fn::FindInMap:
-                  - RegionMap
-                  - Ref: AWS::Region
-                  - QuickStartS3URL
-                - Ref: QSS3BucketName
-                - Ref: QSS3KeyPrefix
-                - scripts/calico.yaml
-            - "\n"
+            # Add-on for network Calico
+            # (http://docs.projectcalico.org/v2.0/getting-started/kubernetes/installation/hosted/kubeadm/)
+            # so pods can communicate
+            kubectl apply -f https://s3.amazonaws.com/${QSS3BucketName}/${QSS3KeyPrefix}/scripts/calico.yaml
+
 
   RecoveryTestAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -383,52 +369,66 @@ Resources:
       - Ref: allow22
       UserData:
         Fn::Base64:
-          Fn::Join:
-          - ''
-          -
-            - |-
-              #!/bin/bash -v
+          Fn::Sub: |
+            #!/bin/bash -v
 
-              # Create directory and file to enable --cloud-provider=aws for kubelet
-              mkdir -p /etc/systemd/system/kubelet.service.d/
+            # Update package lists
+            apt-get update
 
-              cat <<EOF > /etc/systemd/system/kubelet.service.d/20-cloud-provider.conf
-              [Service]
-              Environment="KUBELET_EXTRA_ARGS=--cloud-provider=aws
-              EOF
+            # Install Cloudwatch Logs
+            apt-get -y install python
+            mkdir -p /usr/local/aws
+            wget -O /usr/local/aws/awslogs-agent-setup.py https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py
+            chmod +x /usr/local/aws/awslogs-agent-setup.py
+            #TODO: move config file location to quickstart bucket
+            python /usr/local/aws/awslogs-agent-setup.py -n -r ${AWS::Region} -c http://43d3.brandonchav.is/kubernetes-awslogs.conf
 
-              # Get repository key
-              curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+            cat <<EOF > /etc/systemd/system/awslogs.service
+            [Service]
+            Type=simple
+            Restart=always
+            KillMode=process
+            TimeoutSec=infinity
+            PIDFile=/var/awslogs/state/awslogs.pid
+            ExecStart=/var/awslogs/bin/awslogs-agent-launcher.sh --start --background --pidfile $PIDFILE --user awslogs --chuid awslogs &
+            EOF
 
-              # Append key to sources file
-              cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
-              deb http://apt.kubernetes.io/ kubernetes-xenial main
-              EOF
+            systemctl enable awslogs.service
+            systemctl start awslogs.service
 
-              # Update package lists
-              apt-get update
+            # Create directory and file to enable --cloud-provider=aws for kubelet
+            mkdir -p /etc/systemd/system/kubelet.service.d/
 
-              # Install docker if you don't have it already.
-              apt-get install -y docker.io
+            cat <<EOF > /etc/systemd/system/kubelet.service.d/20-cloud-provider.conf
+            [Service]
+            Environment="KUBELET_EXTRA_ARGS=--cloud-provider=aws"
+            EOF
 
-              # Install kubernetes tools
-              apt-get install -y kubelet kubeadm kubectl kubernetes-cni
+            # Get repository key
+            curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 
-              # reset kubeadm (workaround for kubelet package presence)
-              kubeadm reset
+            # Append key to sources file
+            cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
+            deb http://apt.kubernetes.io/ kubernetes-xenial main
+            EOF
 
-              # Join master node
-              kubeadm join --token=
+            # Install docker if you don't have it already.
+            apt-get install -y docker.io
 
-            - { Ref: ClusterToken }
-            - " "
-            - Fn::GetAtt:
-              - K8sMasterInstance
-              - PrivateIp
-            - "\n"
+            # Install kubernetes tools
+            apt-get install -y kubelet kubeadm kubectl kubernetes-cni
+
+            # reset kubeadm (workaround for kubelet package presence)
+            kubeadm reset
+
+            # Join master node
+            kubeadm join --token=${ClusterToken} ${K8sMasterInstance.PrivateIp}
 
   # Open up port 22 for SSH into each machine
   allow22:
+    Metadata:
+      Comment: Open up port 22 for SSH into each machine
+      Note: Metadata is a way to add comments that will survive linting
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: Enable SSH access via port 22
@@ -475,6 +475,17 @@ Resources:
             - ecr:ListImages
             - ecr:BatchGetImage
             Resource: "*"
+      - PolicyName: cwlogs
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - logs:CreateLogGroup
+            - logs:CreateLogStream
+            - logs:PutLogEvents
+            - logs:DescribeLogStreams
+            Resource: !Sub ["${LogGroupArn}:*", LogGroupArn: !GetAtt KubernetesLogGroup.Arn]
 
   NodeInstanceProfile:
     Type: AWS::IAM::InstanceProfile
@@ -515,6 +526,18 @@ Resources:
             - autoscaling:DescribeAutoScalingGroups
             - autoscaling:UpdateAutoScalingGroup
             Resource: "*"
+      - PolicyName: cwlogs
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - logs:CreateLogGroup
+            - logs:CreateLogStream
+            - logs:PutLogEvents
+            - logs:DescribeLogStreams
+            Resource: !Sub ["${LogGroupArn}:*", LogGroupArn: !GetAtt KubernetesLogGroup.Arn]
+
 
   MasterInstanceProfile:
     Type: AWS::IAM::InstanceProfile


### PR DESCRIPTION
My fork is a bit behind, apologies. I wanted to surface some of these things for consideration.

1) I changed the userdata structure from using Fn:Join to using Fn:Sub. This is cleaner (IMO) and should work for our purposes here, but can cause issues if we need to add something outside of the Fn:Sub block. Fn:Base64 only accepts a string, not a list of objects, which  is why Fn:Join is usually used after Fn:Base64- to concat everything into a string. 

We could also approach the userdata using Fn:Sub like this: https://github.com/aws-quickstart/quickstart-atlassian-bitbucket/blob/0b291a705a001f25c20c9f85b4ee70922a76b6d9/templates/BitbucketDataCenter.template#L1000

2. I added a CWLogs Log Group, but it is statically named and this can cause overlaps if customers launch the template twice. We may consider moving it to a master template so that it only ever gets created once. I suspect customers will want all log streams to show up under the “Heptio-Kuberentes” Log Group.  

An alternative approach is to Fn:Join the AWS::StackName to the Log Group name, but this results in multiple groups. Also, 16.04 isn’t officially supported by the daemon so I had to manually create a unit file. I'm considering dropping CWLogs entirely due to the added complexity here. 

3. Our CI Linter will remove inline "#" comments (however, they will be preserved in userdata). Check out line 429 for using Metadata as an alternative comment method. 

4. I noticed that none of the kube utils are installed; even with the additional sources added it seems that apt-get can’t find them. Did I break something? Sanity check please.