### PR TITLE
Install packages in packer base image

### DIFF
--- a/packer/create-ami.sh
+++ b/packer/create-ami.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Based on the packer scripts used by Weaveworks:
+# https://github.com/weaveworks/kubernetes-ami
+
+set -eu
+
+AWS_BUILDS=('us-west-2,ami-746aba14')
+
+ORIG_DIR=`pwd`
+SCRIPT_DIR="$(cd "$(dirname "$0")"; pwd)"
+cd $SCRIPT_DIR
+
+# ------------------------------------------------------------
+
+# check 'packer' is present
+if [ ! `command -v packer` ]; then
+  echo "'packer' is required but not found!"
+  exit 1
+fi
+
+# ------------------------------------------------------------
+# util functions
+invoke_packer() {
+
+  REGION="$1"
+  BASE_AMI="$2"
+
+  PACKER_VARS="-var ami_groups=${AMI_GROUPS:-all} -var aws_region=${REGION} -var aws_base_ami=${BASE_AMI}"
+
+  echo "PACKER_VARS: $PACKER_VARS"
+
+  packer validate $PACKER_VARS packer-template.json && \
+  echo "Validated OK" && \
+  packer build -force $PACKER_VARS packer-template.json 2>&1 &
+
+}
+# ------------------------------------------------------------
+# execute packer for each region & base AMI
+AMI_GROUPS="${AMI_GROUPS:-all}"
+
+for BUILD in $AWS_BUILDS; do
+
+  array=(${BUILD//,/ })
+
+  AWS_REGION="${array[0]}"
+  AWS_BASE_AMI="${array[1]}"
+
+  invoke_packer $AWS_REGION $AWS_BASE_AMI
+
+done
+
+# ------------------------------------------------------------
+# wait for all to finish
+
+echo "Waiting for builds to finish..."
+
+wait
+
+echo "Done."
+
+cd $ORIG_DIR

--- a/packer/create-ami.sh
+++ b/packer/create-ami.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2017 by the contributors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
 # Based on the packer scripts used by Weaveworks:
 # https://github.com/weaveworks/kubernetes-ami
 

--- a/packer/packer-template.json
+++ b/packer/packer-template.json
@@ -1,0 +1,37 @@
+{
+  "variables": {
+    "aws_access_key": "{{env `AWS_ACCESS_KEY`}}",
+    "aws_secret_key": "{{env `AWS_SECRET_KEY`}}",
+    "aws_region": "us-west-2",
+    "aws_base_ami": "ami-746aba14",
+    "ami_groups": "all"
+  },
+  "builders": [{
+    "type": "amazon-ebs",
+    "access_key": "{{user `aws_access_key`}}",
+    "secret_key": "{{user `aws_secret_key`}}",
+    "region": "{{user `aws_region`}}",
+    "source_ami": "{{user `aws_base_ami`}}",
+    "instance_type": "t2.micro",
+    "ami_name": "Heptio Kubernetes Community AMI (Ubuntu 16.04 LTS {{isotime \"2006-01-02 15.04.05\"}})",
+    "ami_groups": "{{user `ami_groups`}}",
+    "communicator": "ssh",
+    "ssh_username": "ubuntu",
+    "ssh_file_transfer_method": "sftp",
+    "ssh_pty": true
+  }],
+  "provisioners": [
+    {
+      "type": "file",
+      "source": "./prepare-ami.sh",
+      "destination": "/home/ubuntu/prepare-ami.sh"
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "sudo /bin/bash -eux /home/ubuntu/prepare-ami.sh",
+        "rm /home/ubuntu/prepare-ami.sh"
+      ]
+    }
+  ]
+}

--- a/packer/prepare-ami.sh
+++ b/packer/prepare-ami.sh
@@ -1,0 +1,52 @@
+#!/bin/bash -eux
+
+kubernetes_release_tag="v1.5.2"
+kubernetes_release_version=${kubernetes_release_tag/v/}
+
+## Install official Kubernetes package
+
+curl --silent "https://packages.cloud.google.com/apt/doc/apt-key.gpg" | apt-key add -
+
+echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+
+apt-get update -q
+apt-get upgrade -qy
+# Install docker but don't complain that /etc/default/docker has changed
+apt-get install -qy \
+    docker.io \
+    "kubelet=${kubernetes_release_version}-00" \
+    "kubeadm=1.6.0-alpha.0-2074-a092d8e0f95f52-00" \
+    "kubectl=${kubernetes_release_version}-00" \
+    "kubernetes-cni=0.3.0.1-07a8a2-00"
+
+## Also install `jq` and `pip`
+apt-get install -qy jq python-pip python-setuptools
+
+## We will need AWS tools as well
+pip install "https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz"
+pip install awscli
+
+## Pre-fetch Kubernetes release image, so that `kubeadm init` is a bit quicker
+images=(
+  "gcr.io/google_containers/kube-proxy-amd64:${kubernetes_release_tag}"
+  "gcr.io/google_containers/kube-apiserver-amd64:${kubernetes_release_tag}"
+  "gcr.io/google_containers/kube-scheduler-amd64:${kubernetes_release_tag}"
+  "gcr.io/google_containers/kube-controller-manager-amd64:${kubernetes_release_tag}"
+  "gcr.io/google_containers/etcd-amd64:3.0.14-kubeadm"
+  "gcr.io/google_containers/kube-discovery-amd64:1.0"
+  "gcr.io/google_containers/pause-amd64:3.0"
+)
+
+for i in "${images[@]}" ; do docker pull "${i}" ; done
+
+## Save release version, so that we can call `kubeadm init --use-kubernetes-version="$(cat /etc/kubernetes_community_ami_version)` and ensure we get the same version
+echo "${kubernetes_release_tag}" > /etc/kubernetes_community_ami_version
+
+## Cleanup packer SSH key and machine ID generated for this boot
+
+rm /root/.ssh/authorized_keys
+rm /home/ubuntu/.ssh/authorized_keys
+rm /etc/machine-id
+touch /etc/machine-id
+
+## Done!

--- a/packer/prepare-ami.sh
+++ b/packer/prepare-ami.sh
@@ -1,4 +1,18 @@
 #!/bin/bash -eux
+# Copyright 2017 by the contributors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
 
 kubernetes_release_tag="v1.5.2"
 kubernetes_release_version=${kubernetes_release_tag/v/}
@@ -26,7 +40,7 @@ apt-get install -qy jq python-pip python-setuptools
 pip install "https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz"
 pip install awscli
 
-## Pre-fetch Kubernetes release image, so that `kubeadm init` is a bit quicker
+## Pre-fetch various images, so that `kubeadm init` is a bit quicker
 images=(
   "gcr.io/google_containers/kube-proxy-amd64:${kubernetes_release_tag}"
   "gcr.io/google_containers/kube-apiserver-amd64:${kubernetes_release_tag}"
@@ -35,6 +49,13 @@ images=(
   "gcr.io/google_containers/etcd-amd64:3.0.14-kubeadm"
   "gcr.io/google_containers/kube-discovery-amd64:1.0"
   "gcr.io/google_containers/pause-amd64:3.0"
+  "gcr.io/google_containers/etcd:2.2.1"
+  "quay.io/calico/node:v1.0.2"
+  "calico/cni:v1.5.6"
+  "calico/kube-policy-controller:v0.5.2"
+  "calico/ctl:v1.0.2"
+  "weaveworks/weave-kube:1.9.0"
+  "weaveworks/weave-npc:1.9.0"
 )
 
 for i in "${images[@]}" ; do docker pull "${i}" ; done

--- a/packer/prepare-ami.sh
+++ b/packer/prepare-ami.sh
@@ -25,7 +25,6 @@ echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.l
 
 apt-get update -q
 apt-get upgrade -qy
-# Install docker but don't complain that /etc/default/docker has changed
 apt-get install -qy \
     docker.io \
     "kubelet=${kubernetes_release_version}-00" \

--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -207,7 +207,7 @@ Parameters:
     ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters,
       uppercase letters, hyphens (-), and forward slash (/). It cannot start or end
       with forward slash (/) because they are automatically appended.
-    Default: heptio/kubernetes/latest
+    Default: heptio/kubernetes/packerdemo
     Description: S3 key prefix for the Quick Start assets. Quick Start key prefix
       can include numbers, lowercase letters, uppercase letters, hyphens (-), and
       forward slash (/). It cannot start or end with forward slash (/) because they
@@ -231,33 +231,33 @@ Mappings:
   # http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html
   RegionMap:
     ap-northeast-1:
-      '64': ami-18afc47f
+      '64': ami-36cc8051
     ap-northeast-2:
-      '64': ami-93d600fd
+      '64': ami-83a979ed
     ap-south-1:
-      '64': ami-dd3442b2
+      '64': ami-7af28315
     ap-southeast-1:
-      '64': ami-87b917e4
+      '64': ami-ee0eb98d
     ap-southeast-2:
-      '64': ami-e6b58e85
+      '64': ami-4aadac29
     ca-central-1:
-      '64': ami-7112a015
+      '64': ami-be8d30da
     eu-central-1:
-      '64': ami-fe408091
+      '64': ami-7ff63d10
     eu-west-1:
-      '64': ami-ca80a0b9
+      '64': ami-840f2ee2
     eu-west-2:
-      '64': ami-ede2e889
+      '64': ami-60031604
     sa-east-1:
-      '64': ami-e075ed8c
+      '64': ami-6eadca02
     us-east-1:
-      '64': ami-9dcfdb8a
+      '64': ami-125e9004
     us-east-2:
-      '64': ami-fcc19b99
+      '64': ami-d5c6e3b0
     us-west-1:
-      '64': ami-b05203d0
+      '64': ami-913e61f1
     us-west-2:
-      '64': ami-b2d463d2
+      '64': ami-39048359
 
 # Helper Conditions which help find the right values for resources
 Conditions:
@@ -333,22 +333,6 @@ Resources:
           Fn::Sub: |
             #!/bin/bash -v
 
-            # Set up apt before we install anything, so that we only have to `apt-get update` once
-            # Get repository key
-            curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-
-            # Append key to sources file
-            cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
-            deb http://apt.kubernetes.io/ kubernetes-xenial main
-            EOF
-
-            # Update package lists
-            apt-get update
-
-            # Install Cloudwatch bootstap tools and dependencies
-            apt-get install -y unzip python python-setuptools
-            easy_install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
-
             # Install Cloudwatch Logs
             mkdir -p /usr/local/aws
             wget -O /usr/local/aws/awslogs-agent-setup.py https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py
@@ -393,12 +377,6 @@ Resources:
             [Service]
             Environment="KUBELET_EXTRA_ARGS=--cloud-provider=aws"
             EOF
-
-            # Install Docker
-            apt-get install -y docker.io
-
-            # Install kubernetes tools
-            apt-get install -y kubelet kubeadm kubectl kubernetes-cni
 
             # reset kubeadm (workaround for kubelet package presence)
             kubeadm reset
@@ -516,22 +494,6 @@ Resources:
           Fn::Sub: |
             #!/bin/bash -v
 
-            # Set up apt before we install anything, so that we only have to `apt-get update` once
-            # Get repository key
-            curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-
-            # Append key to sources file
-            cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
-            deb http://apt.kubernetes.io/ kubernetes-xenial main
-            EOF
-
-            # Update package lists
-            apt-get update
-
-            # Install Cloudwatch bootstap tools and dependencies
-            apt-get install -y unzip python python-setuptools
-            easy_install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
-
             # Install Cloudwatch Logs
             mkdir -p /usr/local/aws
             wget -O /usr/local/aws/awslogs-agent-setup.py https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py
@@ -576,12 +538,6 @@ Resources:
             [Service]
             Environment="KUBELET_EXTRA_ARGS=--cloud-provider=aws"
             EOF
-
-            # Install Docker
-            apt-get install -y docker.io
-
-            # Install Kubernetes tools
-            apt-get install -y kubelet kubeadm kubectl kubernetes-cni
 
             # reset kubeadm (workaround for kubelet package presence)
             kubeadm reset


### PR DESCRIPTION
This moves the package installation into a base image using packer (packer config taken from https://github.com/weaveworks/kubernetes-ami)

The main change from weaveworks' packer config is that we're not installing weave onto the base image, instead weave is installed from a `kubectl apply` directly on k8s itself.  So the base image is pretty vanilla, with only docker and kubernetes installed.