### PR TITLE
Configure kubelet in AMI setup

### DIFF
--- a/packer/prepare-ami.sh
+++ b/packer/prepare-ami.sh
@@ -23,6 +23,13 @@ curl --silent "https://packages.cloud.google.com/apt/doc/apt-key.gpg" | apt-key 
 
 echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
 
+# Preconfigure kubelet's systemd config to enable --cloud-provider=aws
+mkdir -p /etc/systemd/system/kubelet.service.d/
+cat <<EOF > /etc/systemd/system/kubelet.service.d/20-cloud-provider.conf
+[Service]
+Environment="KUBELET_EXTRA_ARGS=--cloud-provider=aws"
+EOF
+
 apt-get update -q
 apt-get upgrade -qy
 apt-get install -qy \

--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -231,33 +231,33 @@ Mappings:
   # http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html
   RegionMap:
     ap-northeast-1:
-      '64': ami-36cc8051
+      '64': ami-1e094679
     ap-northeast-2:
-      '64': ami-83a979ed
+      '64': ami-1fd20271
     ap-south-1:
-      '64': ami-7af28315
+      '64': ami-a4f584cb
     ap-southeast-1:
-      '64': ami-ee0eb98d
+      '64': ami-ede5538e
     ap-southeast-2:
-      '64': ami-4aadac29
+      '64': ami-4a444429
     ca-central-1:
-      '64': ami-be8d30da
+      '64': ami-988934fc
     eu-central-1:
-      '64': ami-7ff63d10
+      '64': ami-161ed579
     eu-west-1:
-      '64': ami-840f2ee2
+      '64': ami-f0b99896
     eu-west-2:
-      '64': ami-60031604
+      '64': ami-14091c70
     sa-east-1:
-      '64': ami-6eadca02
+      '64': ami-35b1d659
     us-east-1:
-      '64': ami-125e9004
+      '64': ami-3825ec2e
     us-east-2:
-      '64': ami-d5c6e3b0
+      '64': ami-5fc1e43a
     us-west-1:
-      '64': ami-913e61f1
+      '64': ami-492a7529
     us-west-2:
-      '64': ami-39048359
+      '64': ami-933abdf3
 
 # Helper Conditions which help find the right values for resources
 Conditions:

--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -370,14 +370,6 @@ Resources:
             systemctl enable awslogs.service
             systemctl start awslogs.service
 
-            # Create directory and file to enable --cloud-provider=aws for kubelet
-            # This is a systemd file
-            mkdir -p /etc/systemd/system/kubelet.service.d/
-            cat <<EOF > /etc/systemd/system/kubelet.service.d/20-cloud-provider.conf
-            [Service]
-            Environment="KUBELET_EXTRA_ARGS=--cloud-provider=aws"
-            EOF
-
             # reset kubeadm (workaround for kubelet package presence)
             kubeadm reset
 


### PR DESCRIPTION
Previously we were doing this after the first launch, when kubelet was already started, leaving it running with the incorrect arguments.