### PR TITLE
Uses lambda for kubeadm token

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ More complete instructions coming soon.
 ```
 STACK=stack-name
 TEMPLATEPATH=file:///....
-CLUSTERTOKEN=$(python -c 'import random; print "%06x.%016x" % (random.SystemRandom().getrandbits(3*8), random.SystemRandom().getrandbits(8*8))')
 KEYNAME=<aws-key-name>
 AZ=us-west-2b
 aws cloudformation create-stack \
@@ -17,7 +16,6 @@ aws cloudformation create-stack \
   --template-body $TEMPLATEPATH \
   --parameters \
     ParameterKey=AvailabilityZone,ParameterValue=$AZ \
-    ParameterKey=ClusterToken,ParameterValue=$CLUSTERTOKEN \
     ParameterKey=KeyName,ParameterValue=$KEYNAME \
   --capabilities=CAPABILITY_IAM
 ```
@@ -33,7 +31,7 @@ aws s3 sync \
   --exclude '.vscode/*' \
   --exclude .gitmodules \
   --acl=public-read \
-  ./ s3://${HEPTIO_S3_BUCKET)/${HEPTIO_S3_KEY_PREFIX}/
+  ./ s3://${HEPTIO_S3_BUCKET}/${HEPTIO_S3_KEY_PREFIX}/
 ```
 
 If you are using a different bucket/prefix, you need to tell the CFn create-stack about it.
@@ -43,7 +41,6 @@ aws cloudformation create-stack \
   --template-body $TEMPLATEPATH \
   --parameters \
     ParameterKey=AvailabilityZone,ParameterValue=$AZ \
-    ParameterKey=ClusterToken,ParameterValue=$CLUSTERTOKEN \
     ParameterKey=KeyName,ParameterValue=$KEYNAME \
     ParameterKey=QSS3BucketName,ParameterValue=$HEPTIO_S3_BUCKET \
     ParameterKey=QSS3KeyPrefix,ParameterValue=$HEPTIO_S3_KEY_PREFIX \

--- a/templates/kubernetes-cluster-with-new-vpc.template
+++ b/templates/kubernetes-cluster-with-new-vpc.template
@@ -43,7 +43,6 @@ Metadata:
     - Label:
         default: Kubernetes Configuration
       Parameters:
-      - ClusterToken
       - K8sNodeCapacity
       - NetworkingProvider
     - Label:
@@ -59,8 +58,6 @@ Metadata:
         default: Availability Zone
       SSHLocation:
         default: SSH Ingress Location
-      ClusterToken:
-        default: Cluster Token
       InstanceType:
         default: Instance Type
       BastionInstanceType:
@@ -79,12 +76,6 @@ Parameters:
     Description: Existing EC2 KeyPair for SSH access
     Type: AWS::EC2::KeyPair::KeyName
     ConstraintDescription: must be the name of an existing EC2 KeyPair.
-
-  ClusterToken:
-    Description: 'Generate this token (OSX/Linux): LC_CTYPE=c tr -dc ''a-zA-Z0-9'' </dev/urandom | fold -w 22 | head -n 1 | sed ''s/^\(.\{6\}\)/\1\./'''
-    Type: String
-    ConstraintDescription: must be a secure string, which will be used as the token
-      for this cluster, of the format <6 character string>.<16 character string>.
 
   InstanceType:
     Description: EC2 instance type for the cluster
@@ -520,8 +511,6 @@ Resources:
               - '32'
         KeyName:
           Ref: KeyName
-        ClusterToken:
-          Ref: ClusterToken
         K8sNodeCapacity:
           Ref: K8sNodeCapacity
         QSS3BucketName:
@@ -592,13 +581,6 @@ Outputs:
       - K8sStack
       - Outputs.MasterInstanceId
 
-  MasterAZ:
-    Description: Availability Zone of the master
-    Value:
-      Fn::GetAtt:
-      - K8sStack
-      - Outputs.MasterAZ
-
   MasterPrivateIP:
     Description: Private IP address of the master
     Value:
@@ -612,13 +594,6 @@ Outputs:
       Fn::GetAtt:
       - K8sStack
       - Outputs.NodeGroupInstanceId
-
-  ClusterToken:
-    Description: Key that allows nodes to join this cluster; keep secret
-    Value:
-      Fn::GetAtt:
-      - K8sStack
-      - Outputs.ClusterToken
 
   JoinNodes:
     Description: Command to join more nodes to this cluster

--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -43,7 +43,6 @@ Metadata:
     - Label:
         default: Kubernetes Configuration
       Parameters:
-      - ClusterToken
       - K8sNodeCapacity
       - NetworkingProvider
     - Label:
@@ -65,8 +64,6 @@ Metadata:
         default: Subnet
       SSHLocation:
         default: SSH Ingress Location
-      ClusterToken:
-        default: Cluster Token
       InstanceType:
         default: Instance Type
       K8sNodeCapacity:
@@ -95,15 +92,6 @@ Parameters:
   VPCID:
     Description: 'Your VPC to use for this cluster'
     Type: AWS::EC2::VPC::Id
-
-  # Required. This is a new token all nodes will use to join the cluster
-  # Kubernetes requires a token of the format xxxxxx.xxxxxxxxxxxxxxxx
-  ClusterToken:
-    Description: 'Generate this token (requires Python): python -c ''import random;
-      print "%0x.%0x" % (random.SystemRandom().getrandbits(3*8), random.SystemRandom().getrandbits(8*8))'''
-    Type: String
-    ConstraintDescription: must be a secure string, which will be used as the token
-      for this cluster, of the format <6 character string>.<16 character string>.
 
   ClusterSubnetId:
     Description: 'The subnet to use for this cluster.  Must belong to the availability zone above'
@@ -282,7 +270,6 @@ Conditions:
 
 # Resources are the AWS services we want to actually create as part of the Stack
 Resources:
-
   # Install a CloudWatch logging group for system logs for each instance
   KubernetesLogGroup:
     Type: AWS::Logs::LogGroup
@@ -393,7 +380,7 @@ Resources:
             # Initialize master node
             kubeadm init \
               --cloud-provider=aws \
-              --token=${ClusterToken} \
+              --token=${KubeadmToken.Token} \
               --api-external-dns-names=${LoadBalancerHostname} \
               --use-kubernetes-version=v1.5.2
 
@@ -421,6 +408,62 @@ Resources:
             chmod 0600 $KUBECONFIG_OUTPUT
           - LoadBalancerHostname: !GetAtt ApiLoadBalancer.DNSName
             LoadBalancerName: !Ref ApiLoadBalancer
+
+  # IAM role for Lambda function for generating kubeadm token
+  LambdaExecutionRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+        - Effect: "Allow"
+          Principal:
+            Service: ["lambda.amazonaws.com"]
+          Action: "sts:AssumeRole"
+      Path: "/"
+      Policies:
+      - PolicyName: "lambda_policy"
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+          - Effect: "Allow"
+            Action:
+            - "logs:CreateLogGroup"
+            - "logs:CreateLogStream"
+            - "logs:PutLogEvents"
+            Resource: "arn:aws:logs:*:*:*"
+
+  # Lambda Function for generating the kubeadm token
+  GenKubeadmToken:
+    Type: "AWS::Lambda::Function"
+    Properties:
+      Code:
+        ZipFile: |
+          import random
+          import string
+          import cfnresponse
+          def id_generator(size, chars=string.ascii_uppercase + string.ascii_lowercase + string.digits):
+            return ''.join(random.choice(chars) for _ in range(size))
+          def handler(event, context):
+            if event['RequestType'] == 'Delete':
+              cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
+            if event['RequestType'] == 'Create':
+              token = ("%s.%s" % (id_generator(6), id_generator(16)))
+              responseData = {}
+              responseData['Token'] = token
+              cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData)
+              return token
+      Handler: "index.handler"
+      Runtime: "python2.7"
+      Timeout: "5"
+      Role: !GetAtt LambdaExecutionRole.Arn
+
+  # A Custom resource that uses the lambda function to generate our cluster token
+  KubeadmToken:
+    Type: "Custom::GenerateToken"
+    Version: "1.0"
+    Properties:
+      ServiceToken: !GetAtt GenKubeadmToken.Arn
 
   # This is a CloudWatch alarm https://aws.amazon.com/cloudwatch/
   # If the master node is unresponsive for 5 minutes, AWS will attempt to recover it
@@ -576,7 +619,7 @@ Resources:
             kubeadm reset
 
             # Join master node
-            kubeadm join --token=${ClusterToken} ${K8sMasterInstance.PrivateIp}
+            kubeadm join --token=${KubeadmToken.Token} ${K8sMasterInstance.PrivateIp}
 
   # Define the (one) security group for all machines in the cluster.  Keeping
   # just one security group helps with k8s's cloud-provider=aws integration so
@@ -805,41 +848,18 @@ Outputs:
     Value:
       Ref: K8sMasterInstance
 
-  MasterAZ:
-    Description: Availability Zone of the master
-    Value:
-      Fn::GetAtt:
-      - K8sMasterInstance
-      - AvailabilityZone
-
   MasterPrivateIP:
     Description: Private IP address of the master
-    Value:
-      Fn::GetAtt:
-      - K8sMasterInstance
-      - PrivateIp
+    Value: !GetAtt K8sMasterInstance.PrivateIp
 
   NodeGroupInstanceId:
     Description: InstanceId of the newly created NodeGroup
     Value:
       Ref: K8sNodeGroup
 
-  ClusterToken:
-    Description: Key that allows nodes to join this cluster; keep secret
-    Value:
-      Ref: ClusterToken
-
   JoinNodes:
-    Description: Command to join more nodes to this cluster
-    Value:
-      Fn::Join:
-      - ''
-      - - kubeadm join --token=
-        - Ref: ClusterToken
-        - " "
-        - Fn::GetAtt:
-          - K8sMasterInstance
-          - PrivateIp
+    Description: Command to run on node to join it to this cluster
+    Value: !Sub "kubeadm join --token=${KubeadmToken.Token} ${K8sMasterInstance.PrivateIp}"
 
   NextSteps:
     Description: Verify your cluster and deploy a test application. Instructions at


### PR DESCRIPTION
@captainshar -- heads up -- this removes the`ClusterToken` parameter.  It also removes `MasterAZ` output as I think it mostly just adds noise.

Signed-off-by: Joe Beda <joe.github@bedafamily.com>