### PR TITLE
Stops using capital letters in bootstrap token.

### DIFF
--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -420,7 +420,7 @@ Resources:
           import random
           import string
           import cfnresponse
-          def id_generator(size, chars=string.ascii_uppercase + string.ascii_lowercase + string.digits):
+          def id_generator(size, chars=string.ascii_lowercase + string.digits):
             return ''.join(random.choice(chars) for _ in range(size))
           def handler(event, context):
             if event['RequestType'] == 'Delete':


### PR DESCRIPTION
With 1.6 this is getting more concrete and being defined as just lowercase and numbers.

Signed-off-by: Joe Beda <joe.github@bedafamily.com>