### PR TITLE
Split cluster ingress location into SSH and LB

### DIFF
--- a/templates/kubernetes-cluster-with-new-vpc.template
+++ b/templates/kubernetes-cluster-with-new-vpc.template
@@ -38,7 +38,7 @@ Metadata:
     - Label:
         default: Access Configuration
       Parameters:
-      - SSHLocation
+      - AdminIngressLocation
       - KeyName
     - Label:
         default: Kubernetes Configuration
@@ -56,8 +56,8 @@ Metadata:
         default: SSH Key
       AvailabilityZone:
         default: Availability Zone
-      SSHLocation:
-        default: SSH Ingress Location
+      AdminIngressLocation:
+        default: Admin Ingress Location
       InstanceType:
         default: Instance Type
       BastionInstanceType:
@@ -175,12 +175,11 @@ Parameters:
     Type: AWS::EC2::AvailabilityZone::Name
     ConstraintDescription: must be the name of an AWS Availability Zone
 
-  SSHLocation:
-    Description: IP address range that can be used to SSH to the Bastion Host
+  AdminIngressLocation:
+    Description: IP address range that can be used to SSH to the Bastion Host and access the API over HTTPS
     Type: String
     MinLength: '9'
     MaxLength: '18'
-    Default: 0.0.0.0/0
     AllowedPattern: "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})"
     ConstraintDescription: must be a valid IP CIDR range of the form x.x.x.x/x.
 
@@ -444,7 +443,7 @@ Resources:
       - IpProtocol: tcp
         FromPort: '22'
         ToPort: '22'
-        CidrIp: !Ref SSHLocation
+        CidrIp: !Ref AdminIngressLocation
 
   K8sStack:
     Type: AWS::CloudFormation::Stack
@@ -457,6 +456,7 @@ Resources:
         ClusterSubnetId: !Ref PrivateSubnet
         # Direct SSH access only from the bastion host itself
         SSHLocation: !Sub "${BastionHost.PrivateIp}/32"
+        ApiLbLocation: !Ref AdminIngressLocation
         KeyName: !Ref KeyName
         K8sNodeCapacity: !Ref K8sNodeCapacity
         QSS3BucketName: !Ref QSS3BucketName

--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -39,6 +39,7 @@ Metadata:
         default: Access Configuration
       Parameters:
       - SSHLocation
+      - ApiLbLocation
       - KeyName
     - Label:
         default: Kubernetes Configuration
@@ -64,6 +65,8 @@ Metadata:
         default: Subnet
       SSHLocation:
         default: SSH Ingress Location
+      ApiLbLocation:
+        default: API Ingress Location
       InstanceType:
         default: Instance Type
       K8sNodeCapacity:
@@ -161,7 +164,6 @@ Parameters:
     Type: AWS::EC2::AvailabilityZone::Name
     ConstraintDescription: must be the name of an AWS Availability Zone
 
-  # Default 0.0.0.0/0 (all locations)
   # Specifies the IP range from which you will have SSH access over port 22
   # Used in the allow22 SecurityGroup
   SSHLocation:
@@ -169,7 +171,16 @@ Parameters:
     Type: String
     MinLength: '9'
     MaxLength: '18'
-    Default: 0.0.0.0/0
+    AllowedPattern: "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})"
+    ConstraintDescription: must be a valid IP CIDR range of the form x.x.x.x/x.
+
+  # Specifies the IP range from which you will have HTTPS access to the Kubernetes API server load balancer
+  # Used in the ApiLoadBalancerSecGroup SecurityGroup
+  ApiLbLocation:
+    Description: IP address range that can be used to access the API over HTTPs
+    Type: String
+    MinLength: '9'
+    MaxLength: '18'
     AllowedPattern: "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})"
     ConstraintDescription: must be a valid IP CIDR range of the form x.x.x.x/x.
 
@@ -782,7 +793,7 @@ Resources:
       GroupDescription: Security group for API server load balancer
       VpcId: !Ref VPCID
       SecurityGroupIngress:
-        CidrIp: 0.0.0.0/0
+        CidrIp: !Ref ApiLbLocation
         FromPort: 443
         ToPort: 443
         IpProtocol: tcp


### PR DESCRIPTION
The VPC template sticks with just the one parameter (now called "Admin
ingress location"), but the a-la-carte template needs the value to be
split between LB and SSH.

The SSH ingress location in the sub stack is set by the VPC template as
the address of the bastion host, whereas the LB ingress location is set
as the location the user specified.

Signed-off-by: Ken Simon <ninkendo@gmail.com>