### PR TITLE
Add ssh -i flag to SCP command

### DIFF
--- a/packer/README.md
+++ b/packer/README.md
@@ -1,0 +1,41 @@
+# Build the AMI for Heptio's AWS Quick Start
+
+This directory contains the builder scripts for the AWS AMI that's used by Heptio's AWS Quick Start.
+
+Heptio's AMI is in turn built on Ubuntu 16.04 LTS.
+
+## Overview
+
+Look at `prepare-ami.sh` to see what the AMI does:
+
+- Installs Kubernetes from apt.kubernetes.io
+- Sets up Docker, the AWS CLI, and the CloudFormation bootstrap tools
+- Takes care of other requirements
+
+## Prerequisites
+
+To build the AMI, you need:
+
+- [Packer](https://www.packer.io/docs/installation.html)
+- An AWS account
+- The AWS CLI installed and configured
+
+## Build the AMI
+
+From the root of this repository, run:
+
+```
+./packer/create-ami.sh
+```
+
+## Deployment
+
+`create-ami.sh` publishes the AMI to AWS in us-west-2 by default.  You can copy to other regions with:
+
+```
+# Copy AMI to new region
+aws ec2 copy-image --source-region us-west-2 --region $REGION --source-image-id $NEW_AMI_ID --name $NEW_AMI_NAME
+
+# Get the ID of the new AMI in the new region, and make that AMI public...
+aws ec2 --region $REGION modify-image-attribute --image-id $NEW_AMI_IN_NEW_REGION_ID --launch-permission "{\"Add\": [{\"Group\":\"all\"}]}"
+```

--- a/templates/kubernetes-cluster-with-new-vpc.template
+++ b/templates/kubernetes-cluster-with-new-vpc.template
@@ -503,8 +503,11 @@ Outputs:
     Description: Run locally - SSH command to proxy to the master instance
       through the bastion host, to access port 8080 (command to SSH to the master Kubernetes node).
     Value: !Sub >-
-      ssh -A -L8080:localhost:8080
-      -o ProxyCommand='ssh ubuntu@${BastionHost.PublicIp} nc ${K8sStack.Outputs.MasterPrivateIp} 22'
+      SSH_KEY="path/to/${KeyName}.pem";
+      ssh
+      -i $SSH_KEY
+      -A -L8080:localhost:8080
+      -o ProxyCommand='ssh -i \"${!SSH_KEY}\" ubuntu@${BastionHost.PublicIp} nc %h %p'
       ubuntu@${K8sStack.Outputs.MasterPrivateIp}
 
   GetKubeConfigCommand:
@@ -514,9 +517,11 @@ Outputs:
       "export KUBECONFIG=$(pwd)/kubeconfig" to ensure kubectl uses this configuration file.
       About kubectl - https://kubernetes.io/docs/user-guide/prereqs/ 
     Value: !Sub >-
+      SSH_KEY="path/to/${KeyName}.pem";
       scp
-      -o ProxyCommand='ssh ubuntu@${BastionHost.PublicIp} nc ${K8sStack.Outputs.MasterPrivateIp} 22'
-      ubuntu@${K8sStack.Outputs.MasterPrivateIp}:~/kubeconfig kubeconfig
+      -i $SSH_KEY
+      -o ProxyCommand="ssh -i \"${!SSH_KEY}\" ubuntu@${BastionHost.PublicIp} nc %h %p"
+      ubuntu@${K8sStack.Outputs.MasterPrivateIp}:~/kubeconfig ./kubeconfig
 
   # Outputs forwarded from the k8s template
   MasterInstanceId:


### PR DESCRIPTION
Many users save their ec2 keypairs to nonstandard locations and aren't using
ssh-agent, this suggests the `-i` flag to use the path to their key.

Signed-off-by: Ken Simon <ninkendo@gmail.com>