### PR TITLE
WIP: Initial support for 1.6

### DIFF
--- a/packer/create-ami.sh
+++ b/packer/create-ami.sh
@@ -18,7 +18,7 @@
 
 set -eu
 
-AWS_BUILDS=('us-east-2,ami-cc7551a9')
+AWS_BUILDS=('us-west-1,ami-44613824')
 
 ORIG_DIR=`pwd`
 SCRIPT_DIR="$(cd "$(dirname "$0")"; pwd)"

--- a/packer/payload/prepare-ami.sh
+++ b/packer/payload/prepare-ami.sh
@@ -14,9 +14,9 @@
 #    limitations under the License.
 
 SOURCE_DIR="$(cd "$(dirname "$0")"; pwd)"
-KUBERNETES_RELEASE="v1.5.5"
-KUBEADM_RELEASE="v1.6.0-alpha.0.2074+a092d8e0f95f52"
-CNI_RELEASE="07a8a28637e97b22eb8dfe710eeae1344f69d16e"
+KUBERNETES_RELEASE="v1.6.1"
+KUBEADM_RELEASE="v1.6.1"
+CNI_RELEASE="0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff"
 
 apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
 echo "deb https://apt.dockerproject.org/repo ubuntu-$(lsb_release -cs) main" > /etc/apt/sources.list.d/docker.list
@@ -43,7 +43,7 @@ mkdir /tmp/kubebin
   cd /tmp/kubebin
   curl -sf -O "https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_RELEASE}/bin/linux/amd64/kubelet"
   curl -sf -O "https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_RELEASE}/bin/linux/amd64/kubectl"
-  curl -sf -O "https://storage.googleapis.com/kubernetes-release-dev/ci-cross/${KUBEADM_RELEASE}/bin/linux/amd64/kubeadm"
+  curl -sf -O "https://storage.googleapis.com/kubernetes-release/release/${KUBEADM_RELEASE}/bin/linux/amd64/kubeadm"
   curl -sf -O "https://storage.googleapis.com/kubernetes-release/network-plugins/cni-amd64-${CNI_RELEASE}.tar.gz"
 
   install -o root -g root -m 0755 ./kubeadm /usr/bin/kubeadm
@@ -75,17 +75,19 @@ pip install "https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-
 pip install awscli
 
 ## Pre-fetch various images, so that `kubeadm init` is a bit quicker
-## TODO: pre-fetch add-ons that are layed down by kubeadm.
-## Also, address logging and metrics
+## TODO: address logging and metrics
 images=(
   "gcr.io/google_containers/kube-apiserver-amd64:${KUBERNETES_RELEASE}"
   "gcr.io/google_containers/kube-controller-manager-amd64:${KUBERNETES_RELEASE}"
   "gcr.io/google_containers/kube-proxy-amd64:${KUBERNETES_RELEASE}"
   "gcr.io/google_containers/kube-scheduler-amd64:${KUBERNETES_RELEASE}"
   "gcr.io/google_containers/dnsmasq-metrics-amd64:1.0"
-  "gcr.io/google_containers/etcd-amd64:3.0.14-kubeadm"
+  "gcr.io/google_containers/etcd-amd64:3.0.17"
   "gcr.io/google_containers/etcd:2.2.1"
   "gcr.io/google_containers/exechealthz-amd64:1.2"
+  "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.1"
+  "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.1"
+  "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.1"
   "gcr.io/google_containers/kube-discovery-amd64:1.0"
   "gcr.io/google_containers/kube-dnsmasq-amd64:1.4"
   "gcr.io/google_containers/kubedns-amd64:1.9"

--- a/scripts/calico.yaml
+++ b/scripts/calico.yaml
@@ -1,5 +1,5 @@
 ### Downloaded and re-hosted with permission from
-### http://docs.projectcalico.org/v2.1/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
+### http://docs.projectcalico.org/v2.1/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
 
 # This ConfigMap is used to configure a self-hosted Calico installation.
 kind: ConfigMap
@@ -54,13 +54,13 @@ spec:
         k8s-app: calico-etcd
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: |
-          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
-           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       # Only run this pod on the master.
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       nodeSelector:
-        kubeadm.alpha.kubernetes.io/role: master
+        node-role.kubernetes.io/master: ""
       hostNetwork: true
       containers:
         - name: calico-etcd
@@ -123,11 +123,12 @@ spec:
         k8s-app: calico-node
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: |
-          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
-           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       hostNetwork: true
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      serviceAccountName: calico-cni-plugin
       containers:
         # Runs calico/node container on each Kubernetes node.  This
         # container programs network policy and routes on each
@@ -242,13 +243,14 @@ spec:
         k8s-app: calico-policy-controller
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: |
-          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
-           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       # The policy controller must run in the host network namespace so that
       # it isn't governed by policy that would prevent it from working.
       hostNetwork: true
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      serviceAccountName: calico-policy-controller
       containers:
         - name: calico-policy-controller
           image: quay.io/calico/kube-policy-controller:v0.5.4
@@ -268,3 +270,71 @@ spec:
             # kubernetes.default to the correct service clusterIP.
             - name: CONFIGURE_ETC_HOSTS
               value: "true"
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-cni-plugin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-cni-plugin
+subjects:
+- kind: ServiceAccount
+  name: calico-cni-plugin
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calico-cni-plugin
+  namespace: kube-system
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - nodes
+    verbs:
+      - get
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-cni-plugin
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-policy-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-policy-controller
+subjects:
+- kind: ServiceAccount
+  name: calico-policy-controller
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calico-policy-controller
+  namespace: kube-system
+rules:
+  - apiGroups:
+    - ""
+    - extensions
+    resources:
+      - pods
+      - namespaces
+      - networkpolicies
+    verbs:
+      - watch
+      - list
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-policy-controller
+  namespace: kube-system

--- a/scripts/setup-k8s-master.sh.in
+++ b/scripts/setup-k8s-master.sh.in
@@ -28,15 +28,31 @@ test -n "{{ClusterToken}}"
 test -n "{{NetworkingProviderUrl}}"
 test -n "{{Region}}"
 
+# kubeadm wants lowercase for DNS (as it probably should)
+LB_DNS=$(echo "{{LoadBalancerDns}}" | tr 'A-Z' 'a-z')
+
 # reset kubeadm (workaround for kubelet package presence)
 kubeadm reset
 
+cat >/tmp/kubeadm.yaml <<EOF
+---
+apiVersion: kubeadm.k8s.io/v1alpha1
+kind: MasterConfiguration
+token: {{ClusterToken}}
+cloudProvider: aws
+kubernetesVersion: $(cat /etc/kubernetes_community_ami_version)
+apiServerCertSANs:
+- ${LB_DNS}
+EOF
+
 # Initialize master node
-kubeadm init \
-  --cloud-provider=aws \
-  --token={{ClusterToken}} \
-  --api-external-dns-names={{LoadBalancerDns}} \
-  --use-kubernetes-version=$(cat /etc/kubernetes_community_ami_version)
+kubeadm init --config /tmp/kubeadm.yaml
+rm /tmp/kubeadm.yaml
+
+export KUBECONFIG=/etc/kubernetes/admin.conf
+
+# Grant the "admin" user complete access to the cluster
+kubectl create clusterrolebinding admin-cluster-binding --clusterrole=cluster-admin --user=admin
 
 # Add-on for networking providers, so pods can communicate.  see the scripts/
 # directory of the quickstart.  Currently either calico.yaml or weave.yaml
@@ -49,14 +65,12 @@ aws elb register-instances-with-load-balancer \
   --instances ${INSTANCE_ID} \
   --region {{Region}}
 
-# Grab the client config for the admin user and leave it in the user's home dir, but reconfigure it with
-# some sed magic.  What we're doing here:
-# - Replacing the server with the publicly-visible load balancer address
-# - Disabling TLS verification (since the hostname is random and not one of the SANs in the server cert)
-# - Omitting the CA data, since it's not allowed when you're disabling TLS verification
+# Use kubeadm's kubeconfig command to grab a client-cert-authenticated
+# kubeconfig file for administrative access to the cluster.
 KUBECONFIG_OUTPUT=/home/ubuntu/kubeconfig
-cat /etc/kubernetes/admin.conf | \
-  sed "s#server: https://.*:6443#server: https://{{LoadBalancerDns}}#" \
+kubeadm alpha phase kubeconfig client-certs \
+  --client-name admin \
+  --server "https://${LB_DNS}" \
   >$KUBECONFIG_OUTPUT
 chown ubuntu:ubuntu $KUBECONFIG_OUTPUT
 chmod 0600 $KUBECONFIG_OUTPUT

--- a/scripts/weave.yaml
+++ b/scripts/weave.yaml
@@ -1,4 +1,47 @@
-# Snapshotted from https://git.io/weave-kube
+# Snapshotted from https://git.io/weave-kube-1.6
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: weave-net
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - namespaces
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: weave-net
+  namespace: kube-system
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: weave-net
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: weave-net
+subjects:
+- kind: ServiceAccount
+  name: weave-net
+  namespace: kube-system
+---
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -9,16 +52,6 @@ spec:
     metadata:
       labels:
         name: weave-net
-      annotations:
-        scheduler.alpha.kubernetes.io/tolerations: |
-          [
-            {
-              "key": "dedicated",
-              "operator": "Equal",
-              "value": "master",
-              "effect": "NoSchedule"
-            }
-          ]
     spec:
       hostNetwork: true
       hostPID: true
@@ -59,6 +92,13 @@ spec:
           securityContext:
             privileged: true
       restartPolicy: Always
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      serviceAccountName: weave-net
+      securityContext:
+        seLinuxOptions:
+          type: spc_t
       volumes:
         - name: weavedb
           emptyDir: {}

--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -263,34 +263,34 @@ Mappings:
 
   # http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html
   RegionMap:
-    us-east-2:
-      '64': ami-e2082c87
-    ap-south-1:
-      '64': ami-102b587f
-    eu-west-2:
-      '64': ami-5f4e5a3b
-    eu-west-1:
-      '64': ami-c20b39a4
-    ap-northeast-2:
-      '64': ami-6a3dee04
-    ap-northeast-1:
-      '64': ami-3f87df58
-    sa-east-1:
-      '64': ami-3487e758
-    ca-central-1:
-      '64': ami-2e1fa24a
-    ap-southeast-1:
-      '64': ami-3500bd56
-    ap-southeast-2:
-      '64': ami-f6888495
-    eu-central-1:
-      '64': ami-27dd0c48
-    us-east-1:
-      '64': ami-dcfd40ca
     us-west-1:
-      '64': ami-5d48133d
+      '64': ami-a27d27c2
+    ap-south-1:
+      '64': ami-b6b1c2d9
+    eu-west-2:
+      '64': ami-1a00147e
+    eu-west-1:
+      '64': ami-a5e7dec3
+    ap-northeast-2:
+      '64': ami-6d845603
+    ap-northeast-1:
+      '64': ami-cefbdda9
+    sa-east-1:
+      '64': ami-5383e03f
+    ca-central-1:
+      '64': ami-46f94522
+    ap-southeast-1:
+      '64': ami-cc4ef1af
+    ap-southeast-2:
+      '64': ami-025f5161
+    eu-central-1:
+      '64': ami-0169b96e
+    us-east-1:
+      '64': ami-51e66647
+    us-east-2:
+      '64': ami-34caee51
     us-west-2:
-      '64': ami-0462e864
+      '64': ami-6abf290a
 
 # Helper Conditions which help find the right values for resources
 Conditions:
@@ -583,7 +583,7 @@ Resources:
             # This joins the existing cluster with kubeadm.  Kubeadm is preinstalled in the AMI this template uses, so
             # all that's left is to join the cluster with the correct token.
             "03-k8s-setup-node":
-              command: !Sub "kubeadm join --token=${KubeadmToken.Token} ${K8sMasterInstance.PrivateIp}"
+              command: !Sub "kubeadm reset && kubeadm join --token=${KubeadmToken.Token} ${K8sMasterInstance.PrivateIp}:6443"
     Properties:
       # Refers to the NodeInstanceProfile resource, which applies the IAM role for the nodes
       # The IAM role allows us to create further AWS resources (like an EBS drive) from the cluster


### PR DESCRIPTION
Still targeting 1.6 beta 4 for now, but things should be largely the same when
it's released.

Still to do:

- Snapshot the docker images and go back to caching them
- Deploy the AMI to the rest of the regions (this only works in us-west-1)
- Re-host weave's yaml
- Follow up with calico and see about a better URL than referencing their
  master branch (it's pulling calico containers with the :latest tag)

Signed-off-by: Ken Simon <ninkendo@gmail.com>