### PR TITLE
Kubernetes 1.5.5, misc fixes

### DIFF
--- a/scripts/calico.yaml
+++ b/scripts/calico.yaml
@@ -1,5 +1,5 @@
 ### Downloaded and re-hosted with permission from
-### http://docs.projectcalico.org/v2.0/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
+### http://docs.projectcalico.org/v2.1/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
 
 # This ConfigMap is used to configure a self-hosted Calico installation.
 kind: ConfigMap
@@ -12,9 +12,8 @@ data:
   # defined below.
   etcd_endpoints: "http://10.96.232.136:6666"
 
-  # True enables BGP networking, false tells Calico to enforce
-  # policy only, using native networking.
-  enable_bgp: "true"
+  # Configure the Calico backend to use.
+  calico_backend: "bird"
 
   # The CNI network configuration to install on each node.
   cni_network_config: |-
@@ -36,18 +35,6 @@ data:
         }
     }
 
-  # The default IP Pool to be created for the cluster.
-  # Pod IP addresses will be assigned from this pool.
-  ippool.yaml: |
-      apiVersion: v1
-      kind: ipPool
-      metadata:
-        cidr: 192.168.0.0/16
-      spec:
-        ipip:
-          enabled: true
-        nat-outgoing: true
-
 ---
 
 # This manifest installs the Calico etcd on the kubeadm master.  This uses a DaemonSet
@@ -65,7 +52,6 @@ spec:
     metadata:
       labels:
         k8s-app: calico-etcd
-      # TODO: convert tolerations to Fields for 1.6 
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: |
@@ -73,7 +59,6 @@ spec:
            {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       # Only run this pod on the master.
-      # NOTE: There will be 2 different etcds running on the master.
       nodeSelector:
         kubeadm.alpha.kubernetes.io/role: master
       hostNetwork: true
@@ -148,7 +133,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v1.0.2
+          image: quay.io/calico/node:v1.1.0
           env:
             # The location of the Calico etcd cluster.
             - name: ETCD_ENDPOINTS
@@ -157,26 +142,36 @@ spec:
                   name: calico-config
                   key: etcd_endpoints
             # Enable BGP.  Disable to enforce policy only.
-            - name: CALICO_NETWORKING
+            - name: CALICO_NETWORKING_BACKEND
               valueFrom:
                 configMapKeyRef:
                   name: calico-config
-                  key: enable_bgp
+                  key: calico_backend
             # Disable file logging so `kubectl logs` works.
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
             # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
               value: "ACCEPT"
-            # Don't configure a default pool.  This is done by the Job
-            # below.
-            - name: NO_DEFAULT_POOLS
-              value: "true"
+            # Configure the IP Pool from which Pod IPs will be chosen.
+            - name: CALICO_IPV4POOL_CIDR
+              value: "192.168.0.0/16"
+            - name: CALICO_IPV4POOL_IPIP
+              value: "always"
+            # Disable IPv6 on Kubernetes.
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            # Set Felix logging to "info"
+            - name: FELIX_LOGSEVERITYSCREEN
+              value: "info"
             # Auto-detect the BGP IP address.
             - name: IP
               value: ""
           securityContext:
             privileged: true
+          resources:
+            requests:
+              cpu: 250m
           volumeMounts:
             - mountPath: /lib/modules
               name: lib-modules
@@ -187,7 +182,7 @@ spec:
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v1.5.6
+          image: quay.io/calico/cni:v1.6.1
           command: ["/install-cni.sh"]
           env:
             # The location of the Calico etcd cluster.
@@ -256,7 +251,7 @@ spec:
       hostNetwork: true
       containers:
         - name: calico-policy-controller
-          image: calico/kube-policy-controller:v0.5.2
+          image: quay.io/calico/kube-policy-controller:v0.5.4
           env:
             # The location of the Calico etcd cluster.
             - name: ETCD_ENDPOINTS
@@ -273,52 +268,3 @@ spec:
             # kubernetes.default to the correct service clusterIP.
             - name: CONFIGURE_ETC_HOSTS
               value: "true"
-
----
-
-## This manifest deploys a Job which performs one time
-# configuration of Calico
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: configure-calico
-  namespace: kube-system
-  labels:
-    k8s-app: calico
-spec:
-  template:
-    metadata:
-      name: configure-calico
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: |
-          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
-           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
-    spec:
-      hostNetwork: true
-      restartPolicy: OnFailure
-      containers:
-        # Writes basic configuration to datastore.
-        - name: configure-calico
-          image: calico/ctl:v1.0.2
-          args:
-          - apply
-          - -f
-          - /etc/config/calico/ippool.yaml
-          volumeMounts:
-            - name: config-volume
-              mountPath: /etc/config
-          env:
-            # The location of the etcd cluster.
-            - name: ETCD_ENDPOINTS
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: etcd_endpoints
-      volumes:
-       - name: config-volume
-         configMap:
-           name: calico-config
-           items:
-            - key: ippool.yaml
-              path: calico/ippool.yaml

--- a/scripts/weave.yaml
+++ b/scripts/weave.yaml
@@ -24,7 +24,7 @@ spec:
       hostPID: true
       containers:
         - name: weave
-          image: weaveworks/weave-kube:1.9.2
+          image: weaveworks/weave-kube:1.9.4
           command:
             - /home/weave/launch.sh
           livenessProbe:
@@ -52,7 +52,7 @@ spec:
             requests:
               cpu: 10m
         - name: weave-npc
-          image: weaveworks/weave-npc:1.9.2
+          image: weaveworks/weave-npc:1.9.4
           resources:
             requests:
               cpu: 10m

--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -264,33 +264,33 @@ Mappings:
   # http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html
   RegionMap:
     us-east-2:
-      '64': ami-0871556d
+      '64': ami-e2082c87
     ap-south-1:
-      '64': ami-33aada5c
+      '64': ami-102b587f
     eu-west-2:
-      '64': ami-6f9c890b
+      '64': ami-5f4e5a3b
     eu-west-1:
-      '64': ami-f7e0d591
+      '64': ami-c20b39a4
     ap-northeast-2:
-      '64': ami-5fb36031
+      '64': ami-6a3dee04
     ap-northeast-1:
-      '64': ami-16386b71
+      '64': ami-3f87df58
     sa-east-1:
-      '64': ami-efa0c183
+      '64': ami-3487e758
     ca-central-1:
-      '64': ami-a252efc6
+      '64': ami-2e1fa24a
     ap-southeast-1:
-      '64': ami-9f58ebfc
+      '64': ami-3500bd56
     ap-southeast-2:
-      '64': ami-29acae4a
+      '64': ami-f6888495
     eu-central-1:
-      '64': ami-fe8c5b91
+      '64': ami-27dd0c48
     us-east-1:
-      '64': ami-59d5774f
+      '64': ami-dcfd40ca
     us-west-1:
-      '64': ami-19a5fc79
+      '64': ami-5d48133d
     us-west-2:
-      '64': ami-091e9169
+      '64': ami-0462e864
 
 # Helper Conditions which help find the right values for resources
 Conditions:
@@ -806,6 +806,8 @@ Resources:
         InstancePort: 6443
         InstanceProtocol: TCP
         LoadBalancerPort: 443
+      ConnectionSettings:
+        IdleTimeout: 3600
       Subnets:
       - Fn::If:
         - LoadBalancerSubnetProvidedCondition


### PR DESCRIPTION
- Install docker from apt.dockerproject.org, use supported version
- Kubelet startup scripts deployed to /etc instead of /lib
- Bump calico and weave versions (just re-fetched the YAML for each, calico is
  now at v2.1, weave is the latest they have on their site.)
- Change the idle timeout for the API load balancer to 3600s (fixes #51)