### PR TITLE
Add optional EFK stack

### DIFF
--- a/scripts/aws-es-proxy.yaml.in
+++ b/scripts/aws-es-proxy.yaml.in
@@ -1,0 +1,49 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: aws-es-proxy
+  labels:
+    run: aws-es-proxy
+  namespace: kube-system
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      run: aws-es-proxy
+  strategy:
+    rollingUpdate:
+      maxSurge: 2
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        run: aws-es-proxy
+    spec:
+      containers:
+      - args:
+        - -target
+        - http://{{ElasticsearchFqdn}}
+        - -region
+        - {{AwsRegion}}
+        image: cllunsford/aws-signing-proxy
+        imagePullPolicy: Always
+        name: aws-es-proxy
+      restartPolicy: Always
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    run: aws-es-proxy
+  name: elasticsearch-logging
+  namespace: kube-system
+spec:
+  ports:
+  - port: 9200
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    run: aws-es-proxy
+  type: ClusterIP

--- a/scripts/fluentd-daemonset-elasticsearch.yaml
+++ b/scripts/fluentd-daemonset-elasticsearch.yaml
@@ -1,0 +1,47 @@
+# Rehosted from
+# https://raw.githubusercontent.com/fluent/fluentd-kubernetes-daemonset/master/fluentd-daemonset-elasticsearch.yaml
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: fluentd
+  namespace: kube-system
+  labels:
+    k8s-app: fluentd-logging
+    version: v1
+    kubernetes.io/cluster-service: "true"
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: fluentd-logging
+        version: v1
+        kubernetes.io/cluster-service: "true"
+    spec:
+      containers:
+      - name: fluentd
+        image: quay.io/fluent/fluentd-kubernetes-daemonset
+        env:
+          - name:  FLUENT_ELASTICSEARCH_HOST
+            value: "elasticsearch-logging"
+          - name:  FLUENT_ELASTICSEARCH_PORT
+            value: "9200"
+        resources:
+          limits:
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers

--- a/scripts/setup-k8s-master.sh.in
+++ b/scripts/setup-k8s-master.sh.in
@@ -49,6 +49,18 @@ aws elb register-instances-with-load-balancer \
   --instances ${INSTANCE_ID} \
   --region {{Region}}
 
+# Check if we're configured with an elasticsearch proxy instance
+if [[ -n "{{EsProxyConfig}}" ]]; then
+  # Set up a proxy to the elasticsearch cluster
+  kubectl apply -f "{{EsProxyConfig}}"
+fi
+
+# Check if we're configured to set up fluentd to send logs to elasticsearch
+if [[ -n "{{FluentdConfigUrl}}" ]]; then
+  # Set up fluentd
+  kubectl apply -f "{{FluentdConfigUrl}}"
+fi
+
 # Grab the client config for the admin user and leave it in the user's home dir, but reconfigure it with
 # some sed magic.  What we're doing here:
 # - Replacing the server with the publicly-visible load balancer address

--- a/templates/kubernetes-cluster-with-new-vpc-inputs.json
+++ b/templates/kubernetes-cluster-with-new-vpc-inputs.json
@@ -18,6 +18,9 @@
     {
         "ParameterKey": "QSS3KeyPrefix",
         "ParameterValue": "heptio/kubernetes/latest"
+    },
+    {
+        "ParameterKey": "ElasticsearchDomainName",
+        "ParameterValue": "test"
     }
-
 ]

--- a/templates/kubernetes-cluster-with-new-vpc.template
+++ b/templates/kubernetes-cluster-with-new-vpc.template
@@ -37,6 +37,7 @@ Metadata:
       - AvailabilityZone
       - AdminIngressLocation
       - KeyName
+      - ElasticsearchDomainName
     - Label:
         default: Advanced
       Parameters:
@@ -69,6 +70,8 @@ Metadata:
         default: S3 Key Prefix
       NetworkingProvider:
         default: Networking Provider
+      ElasticsearchDomainName:
+        default: Elasticsearch Domain
 
 # The Parameters allow the user to pass custom settings to the stack before creation
 Parameters:
@@ -185,7 +188,7 @@ Parameters:
     ConstraintDescription: must be the name of an AWS Availability Zone
 
   AdminIngressLocation:
-    Description: CIDR block (IP address range) to allow SSH access to the 
+    Description: CIDR block (IP address range) to allow SSH access to the
       bastion host and HTTPS access to the Kubernetes API. Use 0.0.0.0/0
       to allow access from all locations.
     Type: String
@@ -213,13 +216,13 @@ Parameters:
     Default: quickstart-reference
     Description: Only change this if you have set up assets, like your own networking
       configuration, in an S3 bucket. This and the S3 Key Prefix parameter let you access
-      scripts from the scripts/ and templates/ directories of your own fork of the Heptio 
+      scripts from the scripts/ and templates/ directories of your own fork of the Heptio
       Quick Start assets, uploaded to S3 and stored at
       ${bucketname}.s3.amazonaws.com/${prefix}/scripts/somefile.txt.S3. The bucket name
       can include numbers, lowercase letters, uppercase letters, and hyphens (-).
       It cannot start or end with a hyphen (-).
     Type: String
-  
+
   QSS3KeyPrefix:
     AllowedPattern: "^[0-9a-zA-Z-]+(/[0-9a-zA-Z-]+)*$"
     ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters,
@@ -239,9 +242,19 @@ Parameters:
     ConstraintDescription: 'Currently supported values are "calico" and "weave"'
     Default: calico
     Description: Choose the networking provider to use for communication between
-      pods in the Kubernetes cluster. Supported configurations are calico 
+      pods in the Kubernetes cluster. Supported configurations are calico
       (http://docs.projectcalico.org/v2.0/getting-started/kubernetes/installation/hosted/kubeadm/)
       and weave (https://github.com/weaveworks/weave/blob/master/site/kube-addon.md).
+    Type: String
+
+  ElasticsearchDomainName:
+    AllowedPattern: "^([0-9a-z]+([0-9a-z-]*[0-9a-z])*)?$"
+    ConstraintDescription: Elasticsearch domain name can include numbers, lowercase
+      letters, and hyphens (-). It cannot start or end with a hyphen (-).
+    Default: ''
+    Description: Specify an Elasticsearch domain name for log storage and analysis for this Kubernetes cluster.  If set,
+      a new AWS Elasticsearch service will be created with this search domain configured as the default.  Leave blank if
+      you don't want an Elasticsearch cluster to be set up.
     Type: String
 
 Mappings:
@@ -460,7 +473,7 @@ Resources:
         FromPort: '22'
         ToPort: '22'
         CidrIp: !Ref AdminIngressLocation
-  
+
   # Call the cluster template and supply its parameters
   # This creates a second stack that creates the actual Kubernetes cluster
   # within the new VPC
@@ -484,6 +497,7 @@ Resources:
         ClusterAssociation: !Ref AWS::StackName
         NetworkingProvider: !Ref NetworkingProvider
         LoadBalancerSubnetId: !Ref PublicSubnet
+        ElasticsearchDomainName: !Ref ElasticsearchDomainName
 
 Outputs:
   # Outputs from VPC creation
@@ -515,7 +529,7 @@ Outputs:
       file for accessing the new cluster via kubectl, a Kubernetes command line tool.
       Creates a "kubeconfig" file in the current directory. Then, you can run
       "export KUBECONFIG=$(pwd)/kubeconfig" to ensure kubectl uses this configuration file.
-      About kubectl - https://kubernetes.io/docs/user-guide/prereqs/ 
+      About kubectl - https://kubernetes.io/docs/user-guide/prereqs/
     Value: !Sub >-
       SSH_KEY="path/to/${KeyName}.pem";
       scp

--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -40,7 +40,8 @@ Metadata:
       - InstanceType
       - DiskSizeGb
       - ClusterSubnetId
-      - LoadBalancerSubnetId      
+      - LoadBalancerSubnetId
+      - ElasticsearchDomainName
     - Label:
         default: Access Configuration
       Parameters:
@@ -88,6 +89,8 @@ Metadata:
         default: Networking Provider
       LoadBalancerSubnetId:
         default: Load Balancer Subnet
+      ElasticsearchDomainName:
+        default: Elasticsearch Domain
 
 
 # The Parameters allow the user to pass custom settings to the stack before creation
@@ -187,7 +190,7 @@ Parameters:
   # Specifies the IP range from which you will have SSH access over port 22
   # Used in the allow22 SecurityGroup
   SSHLocation:
-    Description: CIDR block (IP address range) to allow SSH access to the 
+    Description: CIDR block (IP address range) to allow SSH access to the
       instances. Use 0.0.0.0/0 to allow access from all locations.
     Type: String
     MinLength: '9'
@@ -223,11 +226,11 @@ Parameters:
     ConstraintDescription: Quick Start bucket name can include numbers, lowercase
       letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen
       (-).
-    
+
     Default: quickstart-reference
     Description: Only change this if you have set up assets, like your own networking
       configuration, in an S3 bucket. This and the S3 Key Prefix parameter let you access
-      scripts from the scripts/ and templates/ directories of your own fork of the Heptio 
+      scripts from the scripts/ and templates/ directories of your own fork of the Heptio
       Quick Start assets, uploaded to S3 and stored at
       ${bucketname}.s3.amazonaws.com/${prefix}/scripts/somefile.txt.S3. The bucket name
       can include numbers, lowercase letters, uppercase letters, and hyphens (-).
@@ -253,9 +256,19 @@ Parameters:
     ConstraintDescription: 'Currently supported values are "calico" and "weave"'
     Default: calico
     Description: Choose the networking provider to use for communication between
-      pods in the Kubernetes cluster. Supported configurations are calico 
+      pods in the Kubernetes cluster. Supported configurations are calico
       (http://docs.projectcalico.org/v2.0/getting-started/kubernetes/installation/hosted/kubeadm/)
       and weave (https://github.com/weaveworks/weave/blob/master/site/kube-addon.md).
+    Type: String
+
+  ElasticsearchDomainName:
+    AllowedPattern: "^([0-9a-z]+([0-9a-z-]*[0-9a-z])*)?$"
+    ConstraintDescription: Elasticsearch domain name can include numbers, lowercase
+      letters, and hyphens (-). It cannot start or end with a hyphen (-).
+    Default: ''
+    Description: Specify an Elasticsearch domain name for log storage and analysis for this Kubernetes cluster.  If set,
+      a new AWS Elasticsearch service will be created with this search domain configured as the default.  Leave blank if
+      you don't want an Elasticsearch cluster to be set up.
     Type: String
 
 # http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/mappings-section-structure.html
@@ -304,6 +317,11 @@ Conditions:
     - Fn::Equals:
       - !Ref LoadBalancerSubnetId
       - ''
+  ElasticsearchDomainCondition:
+    Fn::Not:
+    - Fn::Equals:
+      - !Ref ElasticsearchDomainName
+      - ''
 
 # Resources are the AWS services we want to actually create as part of the Stack
 Resources:
@@ -313,6 +331,34 @@ Resources:
     Properties:
       LogGroupName: !Ref AWS::StackName
       RetentionInDays: 14
+
+  # Set up an ElasticSearch domain for k8s/app logs
+  ElasticsearchDomain:
+    Type: AWS::Elasticsearch::Domain
+    Condition: ElasticsearchDomainCondition
+    Properties:
+      DomainName: !Ref ElasticsearchDomainName
+      ElasticsearchClusterConfig:
+        DedicatedMasterEnabled: false
+        InstanceCount: 1
+        ZoneAwarenessEnabled: false
+        InstanceType: t2.small.elasticsearch
+      EBSOptions:
+        EBSEnabled: true
+        VolumeSize: 10
+        VolumeType: gp2
+      SnapshotOptions:
+        AutomatedSnapshotStartHour: 0
+      AccessPolicies:
+        Version: "2012-10-17"
+        Statement:
+        - Effect: "Allow"
+          Principal:
+            AWS:
+            - !Sub "arn:aws:iam::${AWS::AccountId}:role/${NodeRole}"
+            - !Sub "arn:aws:iam::${AWS::AccountId}:role/${MasterRole}"
+          Action: "es:*"
+          Resource: !Sub "arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/${ElasticsearchDomainName}/*"
 
   # This is an EC2 instance that will serve as our master node
   K8sMasterInstance:
@@ -351,6 +397,28 @@ Resources:
                 ClusterToken: !GetAtt KubeadmToken.Token
                 NetworkingProviderUrl: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/scripts/${NetworkingProvider}.yaml"
                 Region: !Ref AWS::Region
+                EsProxyConfig:
+                  Fn::If:
+                  - ElasticsearchDomainCondition
+                  - !Sub
+                    "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/scripts/fluentd-daemonset-elasticsearch.yaml"
+                  - ''
+                FluentdConfigUrl:
+                  Fn::If:
+                  - ElasticsearchDomainCondition
+                  - '/tmp/aws-es-proxy.yaml'
+                  - ''
+
+            "/tmp/aws-es-proxy.yaml":
+              source: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/scripts/aws-es-proxy.yaml.in"
+              mode: '000644'
+              context:
+                AwsRegion: !Ref AWS::Region
+                ElasticsearchFqdn:
+                  Fn::If:
+                  - ElasticsearchDomainCondition
+                  - !GetAtt ElasticsearchDomain.DomainEndpoint
+                  - ''
 
           commands:
             # Install the Cloudwatch agent with configuration for the current region and log group name


### PR DESCRIPTION
Elasticsearch is hosted on AWS directly, but it's optional depending on whether
you provide an `ElasticsearchDomainName` input.  AWS's ES offering hosts a
Kibana by default so we don't need to implement that, but we do add a fluentd
DaemonSet if you opt into ES.

Signed-off-by: Ken Simon <ninkendo@gmail.com>