### PR TITLE
Kubernetes 1.7.2, plus other fixes

### DIFF
--- a/packer/payload/prepare-ami.sh
+++ b/packer/payload/prepare-ami.sh
@@ -14,7 +14,7 @@
 #    limitations under the License.
 
 SOURCE_DIR="$(cd "$(dirname "$0")"; pwd)"
-KUBERNETES_RELEASE="v1.6.6"
+KUBERNETES_RELEASE="v1.7.2"
 CNI_RELEASE="0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff"
 
 apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
@@ -38,7 +38,7 @@ apt-get install -qy \
 apt-mark hold docker-engine
 
 ## Install official Kubernetes binaries
-mkdir /tmp/kubebin
+mkdir -p /tmp/kubebin
 (
   cd /tmp/kubebin
   curl -sf -O "https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_RELEASE}/bin/linux/amd64/kubelet"
@@ -51,7 +51,7 @@ mkdir /tmp/kubebin
   install -o root -g root -m 0755 ./kubelet /usr/bin/kubelet
 
   # Also install CNI
-  mkdir /opt/cni
+  mkdir -p /opt/cni
   (
     cd /opt/cni
     tar -xzf "/tmp/kubebin/cni-amd64-${CNI_RELEASE}.tar.gz"
@@ -60,13 +60,14 @@ mkdir /tmp/kubebin
 rm -rf /tmp/kubebin
 
 ## Install systemd scripts for kubelet
-sudo mkdir /etc/systemd/system/kubelet.service.d
+sudo mkdir -p /etc/systemd/system/kubelet.service.d
 install -o root -g root -m 0600 "${SOURCE_DIR}/systemd/kubelet.service" \
   /etc/systemd/system/kubelet.service
 install -o root -g root -m 0600 "${SOURCE_DIR}/systemd/10-kubeadm.conf" \
   /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 install -o root -g root -m 0600 "${SOURCE_DIR}/systemd/20-cloud-provider.conf" \
   /etc/systemd/system/kubelet.service.d/20-cloud-provider.conf
+
 systemctl daemon-reload
 systemctl enable kubelet
 
@@ -78,9 +79,9 @@ pip install awscli
 images=(
   "gcr.io/google_containers/etcd-amd64:3.0.17"
   "gcr.io/google_containers/etcd:2.2.1"
-  "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.2"
-  "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.2"
-  "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.2"
+  "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.4"
+  "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.4"
+  "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.4"
   "gcr.io/google_containers/kube-apiserver-amd64:${KUBERNETES_RELEASE}"
   "gcr.io/google_containers/kube-controller-manager-amd64:${KUBERNETES_RELEASE}"
   "gcr.io/google_containers/kube-proxy-amd64:${KUBERNETES_RELEASE}"
@@ -89,8 +90,8 @@ images=(
   "quay.io/calico/cni:v1.9.1"
   "quay.io/calico/kube-policy-controller:v0.6.0"
   "quay.io/calico/node:v1.3.0"
-  "weaveworks/weave-kube:2.0.0"
-  "weaveworks/weave-npc:2.0.0"
+  "weaveworks/weave-kube:2.0.1"
+  "weaveworks/weave-npc:2.0.1"
 )
 
 for i in "${images[@]}" ; do docker pull "${i}" ; done

--- a/scripts/dashboard.yaml
+++ b/scripts/dashboard.yaml
@@ -1,0 +1,98 @@
+# Snapshotted from https://git.io/kube-dashboard
+#
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Configuration to deploy release version of the Dashboard UI compatible with
+# Kubernetes 1.6 (RBAC enabled).
+#
+# Example usage: kubectl create -f <this_file>
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kubernetes-dashboard
+  labels:
+    k8s-app: kubernetes-dashboard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: kubernetes-dashboard
+  namespace: kube-system
+---
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard
+  namespace: kube-system
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      k8s-app: kubernetes-dashboard
+  template:
+    metadata:
+      labels:
+        k8s-app: kubernetes-dashboard
+    spec:
+      containers:
+      - name: kubernetes-dashboard
+        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.6.1
+        ports:
+        - containerPort: 9090
+          protocol: TCP
+        args:
+          # Uncomment the following line to manually specify Kubernetes API server Host
+          # If not specified, Dashboard will attempt to auto discover the API server and connect
+          # to it. Uncomment only if the default does not work.
+          # - --apiserver-host=http://my-address:port
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 9090
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+      serviceAccountName: kubernetes-dashboard
+      # Comment the following tolerations if Dashboard must not be deployed on master
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+---
+kind: Service
+apiVersion: v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard
+  namespace: kube-system
+spec:
+  ports:
+  - port: 80
+    targetPort: 9090
+  selector:
+    k8s-app: kubernetes-dashboard

--- a/scripts/setup-k8s-master.sh.in
+++ b/scripts/setup-k8s-master.sh.in
@@ -31,6 +31,8 @@ test -n "{{Region}}"
 # kubeadm wants lowercase for DNS (as it probably should)
 LB_DNS=$(echo "{{LoadBalancerDns}}" | tr 'A-Z' 'a-z')
 
+HOSTNAME="$(hostname -f)"
+
 # reset kubeadm (workaround for kubelet package presence)
 kubeadm reset
 
@@ -41,6 +43,7 @@ kind: MasterConfiguration
 token: {{ClusterToken}}
 cloudProvider: aws
 kubernetesVersion: $(cat /etc/kubernetes_community_ami_version)
+nodeName: ${HOSTNAME}
 apiServerCertSANs:
 - ${LB_DNS}
 EOF
@@ -55,7 +58,7 @@ export KUBECONFIG=/etc/kubernetes/admin.conf
 kubectl create clusterrolebinding admin-cluster-binding --clusterrole=cluster-admin --user=admin
 
 # Label this node as a master
-kubectl label node "$(hostname -f)" "kubernetes.io/role=master"
+kubectl label node "${HOSTNAME}" "kubernetes.io/role=master"
 
 # Add-on for networking providers, so pods can communicate.  see the scripts/
 # directory of the quickstart.  Currently either calico.yaml or weave.yaml

--- a/scripts/setup-k8s-master.sh.in
+++ b/scripts/setup-k8s-master.sh.in
@@ -84,3 +84,9 @@ kubeadm alpha phase kubeconfig client-certs \
   >$KUBECONFIG_OUTPUT
 chown ubuntu:ubuntu $KUBECONFIG_OUTPUT
 chmod 0600 $KUBECONFIG_OUTPUT
+
+# And for local debugging, set up ~/.kube/config for the main user account on
+# the master.
+mkdir -p /home/ubuntu/.kube
+cp /etc/kubernetes/admin.conf /home/ubuntu/.kube/config
+chown -R ubuntu:ubuntu /home/ubuntu/.kube

--- a/scripts/setup-k8s-master.sh.in
+++ b/scripts/setup-k8s-master.sh.in
@@ -26,6 +26,7 @@ test -n "{{LoadBalancerDns}}"
 test -n "{{LoadBalancerName}}"
 test -n "{{ClusterToken}}"
 test -n "{{NetworkingProviderUrl}}"
+test -n "{{DashboardUrl}}"
 test -n "{{Region}}"
 
 # kubeadm wants lowercase for DNS (as it probably should)
@@ -63,6 +64,9 @@ kubectl label node "${HOSTNAME}" "kubernetes.io/role=master"
 # Add-on for networking providers, so pods can communicate.  see the scripts/
 # directory of the quickstart.  Currently either calico.yaml or weave.yaml
 kubectl apply -f {{NetworkingProviderUrl}}
+
+# Install the kubernetes dashboard by default
+kubectl apply -f {{DashboardUrl}}
 
 INSTANCE_ID=$(ec2metadata --instance-id)
 # Add this machine (master) to the load balancer for external access

--- a/scripts/weave.yaml
+++ b/scripts/weave.yaml
@@ -6,9 +6,9 @@ items:
     kind: ServiceAccount
     metadata:
       name: weave-net
-      namespace: kube-system
       labels:
         name: weave-net
+      namespace: kube-system
   - apiVersion: rbac.authorization.k8s.io/v1beta1
     kind: ClusterRole
     metadata:
@@ -52,9 +52,9 @@ items:
     kind: DaemonSet
     metadata:
       name: weave-net
-      namespace: kube-system
       labels:
         name: weave-net
+      namespace: kube-system
     spec:
       template:
         metadata:
@@ -71,7 +71,7 @@ items:
                     fieldRef:
                       apiVersion: v1
                       fieldPath: spec.nodeName
-              image: 'weaveworks/weave-kube:2.0.0'
+              image: 'weaveworks/weave-kube:2.0.1'
               livenessProbe:
                 httpGet:
                   host: 127.0.0.1
@@ -97,7 +97,7 @@ items:
                 - name: lib-modules
                   mountPath: /lib/modules
             - name: weave-npc
-              image: 'weaveworks/weave-npc:2.0.0'
+              image: 'weaveworks/weave-npc:2.0.1'
               resources:
                 requests:
                   cpu: 10m

--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -350,6 +350,7 @@ Resources:
                 LoadBalancerName: !Ref ApiLoadBalancer
                 ClusterToken: !GetAtt KubeadmToken.Token
                 NetworkingProviderUrl: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/scripts/${NetworkingProvider}.yaml"
+                DashboardUrl: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/scripts/dashboard.yaml"
                 Region: !Ref AWS::Region
 
           commands:

--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -264,33 +264,33 @@ Mappings:
   # http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html
   RegionMap:
     us-west-1:
-      '64': ami-e7604c87
+      '64': ami-74012814
     ap-south-1:
-      '64': ami-d82759b7
+      '64': ami-1e6d1571
     eu-west-2:
-      '64': ami-6a17010e
+      '64': ami-7942531d
     eu-west-1:
-      '64': ami-c99f84af
+      '64': ami-421bf53b
     ap-northeast-2:
-      '64': ami-d61fc0b8
+      '64': ami-d373adbd
     ap-northeast-1:
-      '64': ami-58786f3f
+      '64': ami-eb81608d
     sa-east-1:
-      '64': ami-88c5aee4
+      '64': ami-00dfab6c
     ca-central-1:
-      '64': ami-9cac13f8
+      '64': ami-d3338cb7
     ap-southeast-1:
-      '64': ami-b4f877d7
+      '64': ami-1364f470
     ap-southeast-2:
-      '64': ami-40eafa23
+      '64': ami-115f4072
     eu-central-1:
-      '64': ami-dfa204b0
+      '64': ami-eb852884
     us-east-1:
-      '64': ami-a90a20bf
+      '64': ami-2d4d5f3b
     us-east-2:
-      '64': ami-cf7756aa
+      '64': ami-d77454b2
     us-west-2:
-      '64': ami-9fdacee6
+      '64': ami-025e467b
 
 # Helper Conditions which help find the right values for resources
 Conditions:
@@ -395,6 +395,16 @@ Resources:
           - AssociationProvidedCondition
           - !Ref ClusterAssociation
           - !Ref AWS::StackName
+        # Also tag it with kubernetes.io/cluster/clustername=owned, which is the newer convention for cluster resources
+      - Key:
+          Fn::Sub:
+          - "kubernetes.io/cluster/${ClusterID}"
+          - ClusterID:
+              Fn::If:
+              - AssociationProvidedCondition
+              - !Ref ClusterAssociation
+              - !Ref AWS::StackName
+        Value: 'owned'
       # http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-imageid
       ImageId:
         Fn::FindInMap:
@@ -550,6 +560,17 @@ Resources:
           - !Ref ClusterAssociation
           - !Ref AWS::StackName
         PropagateAtLaunch: 'true'
+        # Also tag it with kubernetes.io/cluster/clustername=owned, which is the newer convention for cluster resources
+      - Key:
+          Fn::Sub:
+          - "kubernetes.io/cluster/${ClusterID}"
+          - ClusterID:
+              Fn::If:
+              - AssociationProvidedCondition
+              - !Ref ClusterAssociation
+              - !Ref AWS::StackName
+        Value: 'owned'
+        PropagateAtLaunch: 'true'
     # Tells the group how many instances to update at a time, if an update is applied
     UpdatePolicy:
       AutoScalingRollingUpdate:
@@ -583,7 +604,7 @@ Resources:
             # This joins the existing cluster with kubeadm.  Kubeadm is preinstalled in the AMI this template uses, so
             # all that's left is to join the cluster with the correct token.
             "03-k8s-setup-node":
-              command: !Sub "kubeadm reset && kubeadm join --token=${KubeadmToken.Token} ${K8sMasterInstance.PrivateIp}:6443"
+              command: !Sub "kubeadm reset && kubeadm join --node-name=\"$(hostname -f)\" --token=${KubeadmToken.Token} ${K8sMasterInstance.PrivateIp}:6443"
     Properties:
       # Refers to the NodeInstanceProfile resource, which applies the IAM role for the nodes
       # The IAM role allows us to create further AWS resources (like an EBS drive) from the cluster
@@ -646,6 +667,15 @@ Resources:
           - AssociationProvidedCondition
           - !Ref ClusterAssociation
           - !Ref AWS::StackName
+      - Key:
+          Fn::Sub:
+          - "kubernetes.io/cluster/${ClusterID}"
+          - ClusterID:
+              Fn::If:
+              - AssociationProvidedCondition
+              - !Ref ClusterAssociation
+              - !Ref AWS::StackName
+        Value: 'owned'
       - Key: Name
         Value: k8s-cluster-security-group
 
@@ -822,6 +852,15 @@ Resources:
           - AssociationProvidedCondition
           - !Ref ClusterAssociation
           - !Ref AWS::StackName
+      - Key:
+          Fn::Sub:
+          - "kubernetes.io/cluster/${ClusterID}"
+          - ClusterID:
+              Fn::If:
+              - AssociationProvidedCondition
+              - !Ref ClusterAssociation
+              - !Ref AWS::StackName
+        Value: 'owned'
       - Key: 'kubernetes.io/service-name'
         Value: 'kube-system/apiserver-public'
 

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -18,11 +18,11 @@ These commands will delete all load balancers in the stack.  (Warning: this is d
 
 ```
 # Set to the VPC that you want to delete. Example: vpc-1234abcd
-export VPC_IC='<vpc-id>'
+export VPC_ID='<vpc-id>'
 # Set to the region in which you created the Quick Start.  Example: us-west-1
 export AWS_DEFAULT_REGION='<aws-region>'
 
-aws elb describe-load-balancers --query "LoadBalancerDescriptions[?VPCId == \`${VPCID}\`].LoadBalancerName" --output text \
+aws elb describe-load-balancers --query "LoadBalancerDescriptions[?VPCId == \`${VPC_ID}\`].LoadBalancerName" --output text \
     | xargs -n 1 echo \
     | while read lb; do
           aws elb delete-load-balancer --load-balancer-name="${lb}"


### PR DESCRIPTION
- Pass --node-name to kubeadm to make it explicit (based on the host's FQDN), 1.7.x kubeadm doesn't appear to consistently guess EC2 node names
- Get new version of weave
- Fix typo in troubleshooting.md
- Use newer tagging convention for kubernetes resources
- Add kubernetes dashboard by default
- Set up ~/.kube/config on master by default