### PR TITLE
Allow for override of runtime kubernetes binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ To deploy your own changes manually from source, you'll need to upload the conte
 
 If you're making changes to things like the Kubernetes version or anything installed in the base AMI, you'll also need to rebuild the AMI with Packer.  See the "Local development" section below for more details.
 
+Optionally, aws-quickstart also supports overriding a few select kubernetes binaries (kubelet, kubeadm, kubectl) at runtime for development purposes.  To replace these binaries at runtime, simply place your custom versions into the `$S3_PREFIX/bin/` folder:
+```
+$ aws s3 ls s3://quickstart/overrides/bin/
+2017-09-08 13:04:02   71453136 kubeadm
+2017-09-08 12:58:27   72501019 kubectl
+2017-09-08 12:58:27  146464528 kubelet
+```
+These will be downloaded during cloudformation initialization and subsequently become available to the running instance.
+
 An example deployment:
 
 ```

--- a/scripts/kubernetes-override-binaries.sh.in
+++ b/scripts/kubernetes-override-binaries.sh.in
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Copyright 2017 by the contributors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+
+set -o verbose
+set -o errexit
+set -o nounset
+set -o pipefail
+
+test -n "{{BaseBinaryUrl}}"
+url_base="{{BaseBinaryUrl}}"
+
+for binary in kubelet kubeadm kubectl; do
+    url=${url_base%/}/$binary
+
+    echo "Attempting to download: $url"
+    if /usr/bin/curl -f -o /tmp/$binary "$url"; then
+        md5=($(/usr/bin/md5sum /tmp/$binary))
+        echo "Installing override binary $binary with md5sum: $md5"
+        /usr/bin/install -o root -g root -m 0755 /tmp/$binary /usr/bin/$binary
+    
+        if [ "$binary" == "kubelet" ]; then
+            /bin/systemctl daemon-reload
+            /bin/systemctl restart kubelet
+        fi
+    fi
+done;

--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -324,6 +324,13 @@ Resources:
           master-setup: master-setup
         master-setup:
           files:
+            # Script that will allow for development kubernetes binaries to replace the pre-packaged AMI binaries.
+            "/tmp/kubernetes-override-binaries.sh":
+              source: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/scripts/kubernetes-override-binaries.sh.in"
+              mode: '000755'
+              context:
+                BaseBinaryUrl: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/bin/"
+
             # Configuration file for the cloudwatch agent. The file is a Mustache template, and we're creating it with
             # the below context (mainly to substitute in the AWS Stack Name for the logging group.)
             "/tmp/kubernetes-awslogs.conf":
@@ -354,6 +361,9 @@ Resources:
                 Region: !Ref AWS::Region
 
           commands:
+            # Override the AMI binaries with any kubelet/kubeadm/kubectl binaries in the S3 bucket
+            "00-kubernetes-override-binaries":
+              command: "/tmp/kubernetes-override-binaries.sh"
             # Install the Cloudwatch agent with configuration for the current region and log group name
             "01-cloudwatch-agent-setup":
               command: !Sub "python /usr/local/aws/awslogs-agent-setup.py -n -r ${AWS::Region} -c /tmp/kubernetes-awslogs.conf"
@@ -588,6 +598,11 @@ Resources:
         node-setup:
           # (See comments in the master instance Metadata for details.)
           files:
+            "/tmp/kubernetes-override-binaries.sh":
+              source: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/scripts/kubernetes-override-binaries.sh.in"
+              mode: '000755'
+              context:
+                BaseBinaryUrl: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/bin/"
             "/tmp/kubernetes-awslogs.conf":
               source: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/scripts/kubernetes-awslogs.conf"
               context:
@@ -598,6 +613,8 @@ Resources:
             "/etc/systemd/system/awslogs.service":
               source: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/scripts/awslogs.service"
           commands:
+            "00-kubernetes-override-binaries":
+              command: "/tmp/kubernetes-override-binaries.sh"
             "01-cloudwatch-agent-setup":
               command: !Sub "python /usr/local/aws/awslogs-agent-setup.py -n -r ${AWS::Region} -c /tmp/kubernetes-awslogs.conf"
             "02-cloudwatch-service-config":


### PR DESCRIPTION
When testing changes to kubelet, kubeadm, or kubectl it can be quite
handy to have an easily deployable stack. While aws-quickstart provides
much of what is needed, having to rebuild an AMI for every change to a
kubernetes component can be a bit onerous.

This change allows one to place kubernetes binaries into the S3_PREFIX
location. If there are present, they will be downloaded and ultimately
replace the pre-packages binaries.