### PR TITLE
Follow redirects when overriding

### DIFF
--- a/scripts/kubernetes-override-binaries.sh.in
+++ b/scripts/kubernetes-override-binaries.sh.in
@@ -27,7 +27,7 @@ for binary in kubelet kubeadm kubectl; do
     url=${url_base%/}/$binary
 
     echo "Attempting to download: $url"
-    if /usr/bin/curl -f -o /tmp/$binary "$url"; then
+    if /usr/bin/curl -Lf -o /tmp/$binary "$url"; then
         md5=($(/usr/bin/md5sum /tmp/$binary))
         echo "Installing override binary $binary with md5sum: $md5"
         /usr/bin/install -o root -g root -m 0755 /tmp/$binary /usr/bin/$binary


### PR DESCRIPTION
It seems there are some cases when s3 will respond with a redirect. This
ultimately means that curl will return a 0 and that the override script
will proceed. Unfortunately, the temporary redirect does not guarantee
that the target object will ever return a 200.

In order to address this case, be sure to follow all redirects until we
have a definitive reponse code.

Signed-off-by: Craig Tracey <ctracey@heptio.com>