### PR TITLE
Add default storage class.

### DIFF
--- a/scripts/default.storageclass.yaml
+++ b/scripts/default.storageclass.yaml
@@ -1,0 +1,9 @@
+apiVersion: storage.k8s.io/v1beta1
+kind: StorageClass
+metadata:
+  name: gp2
+  annotations:
+    storageclass.beta.kubernetes.io/is-default-class: "true"
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp2

--- a/scripts/setup-k8s-master.sh.in
+++ b/scripts/setup-k8s-master.sh.in
@@ -27,6 +27,7 @@ test -n "{{LoadBalancerName}}"
 test -n "{{ClusterToken}}"
 test -n "{{NetworkingProviderUrl}}"
 test -n "{{DashboardUrl}}"
+test -n "{{StorageClassUrl}}"
 test -n "{{Region}}"
 
 # kubeadm wants lowercase for DNS (as it probably should)
@@ -67,6 +68,9 @@ kubectl apply -f {{NetworkingProviderUrl}}
 
 # Install the kubernetes dashboard by default
 kubectl apply -f {{DashboardUrl}}
+
+# Install the default StorageClass
+kubectl apply -f {{StorageClassUrl}}
 
 INSTANCE_ID=$(ec2metadata --instance-id)
 # Add this machine (master) to the load balancer for external access

--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -358,6 +358,7 @@ Resources:
                 ClusterToken: !GetAtt KubeadmToken.Token
                 NetworkingProviderUrl: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/scripts/${NetworkingProvider}.yaml"
                 DashboardUrl: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/scripts/dashboard.yaml"
+                StorageClassUrl: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/scripts/default.storageclass.yaml"
                 Region: !Ref AWS::Region
 
           commands:


### PR DESCRIPTION
This PR adds a default storage class (gp2) to clusters launched.  This means that PVCs like the following will have an EBS volume dynamically provisioned.

```
# pvc.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: test-pvc
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 10Gi
```

This feature was requested in #80 and we have had at least one user struggle with our [Wordpress Tutorial](http://docs.heptio.com/content/tutorials/aws-qs-helm-wordpress.html) because their PV/EBS were not being created automatically.

Fixes: #80

cc: @rbankston 

