### PR TITLE
Kubernetes v1.8.4

### DIFF
--- a/packer/payload/prepare-ami.sh
+++ b/packer/payload/prepare-ami.sh
@@ -14,7 +14,7 @@
 #    limitations under the License.
 
 SOURCE_DIR="$(cd "$(dirname "$0")"; pwd)"
-KUBERNETES_RELEASE="v1.8.2"
+KUBERNETES_RELEASE="v1.8.4"
 CNI_RELEASE="0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff"
 
 apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D

--- a/scripts/setup-k8s-master.sh.in
+++ b/scripts/setup-k8s-master.sh.in
@@ -46,7 +46,7 @@ token: {{ClusterToken}}
 cloudProvider: aws
 kubernetesVersion: $(cat /etc/kubernetes_community_ami_version)
 nodeName: ${HOSTNAME}
-tokenTTL: 94608000s
+tokenTTL: 0s
 apiServerCertSANs:
 - ${LB_DNS}
 EOF

--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -263,35 +263,34 @@ Mappings:
 
   # http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html
   RegionMap:
-  RegionMap:
     us-west-1:
-      '64': ami-965965f6
+      '64': ami-39023959
     ap-south-1:
-      '64': ami-27d59748
+      '64': ami-5399d73c
     eu-west-2:
-      '64': ami-22908d46
+      '64': ami-a3a1bec7
     eu-west-1:
-      '64': ami-a7df7ade
+      '64': ami-31d36048
     ap-northeast-2:
-      '64': ami-4401a42a
+      '64': ami-0d379063
     ap-northeast-1:
-      '64': ami-ad60c1cb
+      '64': ami-24de6742
     sa-east-1:
-      '64': ami-db1860b7
+      '64': ami-bb4206d7
     ca-central-1:
-      '64': ami-c7843ca3
+      '64': ami-ab5ae1cf
     ap-southeast-1:
-      '64': ami-dce8a9bf
+      '64': ami-5f0c5f3c
     ap-southeast-2:
-      '64': ami-408c6322
+      '64': ami-3882775a
     eu-central-1:
-      '64': ami-3058e35f
+      '64': ami-57ec6038
     us-east-1:
-      '64': ami-9fa90ee5
+      '64': ami-6369fa19
     us-east-2:
-      '64': ami-4686aa23
+      '64': ami-e89eb08d
     us-west-2:
-      '64': ami-f431fe8c
+      '64': ami-7ed30d06
 
 # Helper Conditions which help find the right values for resources
 Conditions:


### PR DESCRIPTION
This is just the version bump and one fix that got added to v1.8.3.

We no longer have to set a 3 year expiry on the token, it now lives forever so that our ASG won't break 3 years later.

Signed-off-by: Chuck Ha <chuck@heptio.com>