### PR TITLE
WIP: Be very explicit about the hostname we use

### DIFF
--- a/scripts/setup-kubelet-hostname.sh
+++ b/scripts/setup-kubelet-hostname.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+HOSTNAME="$(hostname -f)"
+
+/bin/cat > /etc/systemd/system/kubelet.service.d/10-hostname.conf <<EOF
+[Service]
+Environment="KUBELET_EXTRA_ARGS= --hostname-override=${HOSTNAME}"
+EOF
+systemctl daemon-reload
+systemctl restart kubelet

--- a/templates/kubernetes-cluster-with-new-vpc.template
+++ b/templates/kubernetes-cluster-with-new-vpc.template
@@ -337,7 +337,7 @@ Mappings:
     sa-east-1:
       '64': ami-e075ed8c
     us-east-1:
-      '64': ami-957920ef
+      '64': ami-9dcfdb8a
     us-east-2:
       '64': ami-fcc19b99
     us-west-1:

--- a/templates/kubernetes-cluster-with-new-vpc.template
+++ b/templates/kubernetes-cluster-with-new-vpc.template
@@ -337,7 +337,7 @@ Mappings:
     sa-east-1:
       '64': ami-e075ed8c
     us-east-1:
-      '64': ami-9dcfdb8a
+      '64': ami-957920ef
     us-east-2:
       '64': ami-fcc19b99
     us-west-1:

--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -330,7 +330,7 @@ Mappings:
     eu-central-1:
       '64': ami-57ec6038
     us-east-1:
-      '64': ami-6369fa19
+      '64': ami-957920ef
     us-east-2:
       '64': ami-e89eb08d
     us-west-2:
@@ -391,6 +391,11 @@ Resources:
             "/etc/systemd/system/awslogs.service":
               source: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/scripts/awslogs.service"
 
+            # setup kubelet hostname
+            "/tmp/setup-kubelet-hostname.sh":
+              source: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/scripts/setup-kubelet-hostname.sh"
+              mode: '000755'
+
             # Setup script for initializing the Kubernetes master instance.  This is where most of the cluster
             # initialization happens.  See scripts/setup-k8s-master.sh in the Quick Start repo for details.
             "/tmp/setup-k8s-master.sh":
@@ -416,9 +421,11 @@ Resources:
             # Enable the Cloudwatch service and launch it
             "02-cloudwatch-service-config":
               command: "systemctl enable awslogs.service && systemctl start awslogs.service"
-
+            # Setup kubelet hostname
+            "03-setup-kubelet-hostname":
+              command: "/tmp/setup-kubelet-hostname.sh"
             # Run the master setup
-            "03-master-setup":
+            "04-master-setup":
               command: "/tmp/setup-k8s-master.sh"
     Properties:
       # Where the EC2 instance gets deployed geographically
@@ -481,14 +488,17 @@ Resources:
             #!/bin/bash
             set -o xtrace
 
-            /usr/local/bin/cfn-init \
+            CFN_INIT=$(which cfn-init)
+            CFN_SIGNAL=$(which cfn-signal)
+
+            ${!CFN_INIT} \
               --verbose \
               --stack '${AWS::StackName}' \
               --region '${AWS::Region}' \
               --resource K8sMasterInstance \
               --configsets master-setup
 
-            /usr/local/bin/cfn-signal \
+            ${!CFN_SIGNAL} \
               --exit-code $? \
               --stack '${AWS::StackName}' \
               --region '${AWS::Region}' \
@@ -658,6 +668,9 @@ Resources:
               mode: '000755'
             "/etc/systemd/system/awslogs.service":
               source: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/scripts/awslogs.service"
+            "/tmp/setup-kubelet-hostname.sh":
+              source: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/scripts/setup-kubelet-hostname.sh"
+              mode: '000755'
           commands:
             "00-kubernetes-override-binaries":
               command: "/tmp/kubernetes-override-binaries.sh"
@@ -665,9 +678,11 @@ Resources:
               command: !Sub "python /usr/local/aws/awslogs-agent-setup.py -n -r ${AWS::Region} -c /tmp/kubernetes-awslogs.conf"
             "02-cloudwatch-service-config":
               command: "systemctl enable awslogs.service && systemctl start awslogs.service"
+            "03-setup-kubelet-hostname":
+              command: "/tmp/setup-kubelet-hostname.sh"
             # This joins the existing cluster with kubeadm.  Kubeadm is preinstalled in the AMI this template uses, so
             # all that's left is to join the cluster with the correct token.
-            "03-k8s-setup-node":
+            "04-k8s-setup-node":
               command: !Sub "kubeadm reset && kubeadm join --node-name=\"$(hostname -f)\" --token=${KubeadmToken.Token} ${K8sMasterInstance.PrivateIp}:6443"
     Properties:
       # Refers to the NodeInstanceProfile resource, which applies the IAM role for the nodes

--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -307,34 +307,36 @@ Mappings:
 
   # http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html
   RegionMap:
-    us-west-1:
-      '64': ami-39023959
-    ap-south-1:
-      '64': ami-5399d73c
-    eu-west-2:
-      '64': ami-a3a1bec7
-    eu-west-1:
-      '64': ami-31d36048
-    ap-northeast-2:
-      '64': ami-0d379063
-    ap-northeast-1:
-      '64': ami-24de6742
-    sa-east-1:
-      '64': ami-bb4206d7
-    ca-central-1:
-      '64': ami-ab5ae1cf
-    ap-southeast-1:
-      '64': ami-5f0c5f3c
-    ap-southeast-2:
-      '64': ami-3882775a
-    eu-central-1:
-      '64': ami-57ec6038
     us-east-1:
       '64': ami-957920ef
+    ap-south-1:
+      '64': ami-ea306785
+    eu-west-3:
+      '64': ami-b2f640cf
+    eu-west-2:
+      '64': ami-3e5d465a
+    eu-west-1:
+      '64': ami-05dd4f7c
+    ap-northeast-2:
+      '64': ami-8e9b3be0
+    ap-northeast-1:
+      '64': ami-875dc5e1
+    sa-east-1:
+      '64': ami-3c662450
+    ca-central-1:
+      '64': ami-339a1f57
+    ap-southeast-1:
+      '64': ami-859be8f9
+    ap-southeast-2:
+      '64': ami-db35c8b9
+    eu-central-1:
+      '64': ami-fd188a92
     us-east-2:
-      '64': ami-e89eb08d
+      '64': ami-299fb44c
+    us-west-1:
+      '64': ami-b95350d9
     us-west-2:
-      '64': ami-7ed30d06
+      '64': ami-ec962194
 
 # Helper Conditions which help find the right values for resources
 Conditions:

--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -683,7 +683,7 @@ Resources:
             # This joins the existing cluster with kubeadm.  Kubeadm is preinstalled in the AMI this template uses, so
             # all that's left is to join the cluster with the correct token.
             "04-k8s-setup-node":
-              command: !Sub "kubeadm reset && kubeadm join --node-name=\"$(hostname -f)\" --token=${KubeadmToken.Token} ${K8sMasterInstance.PrivateIp}:6443"
+              command: !Sub "kubeadm reset && kubeadm join --discovery-token-unsafe-skip-ca-verification --node-name=\"$(hostname -f)\" --token=${KubeadmToken.Token} ${K8sMasterInstance.PrivateIp}:6443"
     Properties:
       # Refers to the NodeInstanceProfile resource, which applies the IAM role for the nodes
       # The IAM role allows us to create further AWS resources (like an EBS drive) from the cluster


### PR DESCRIPTION
There is a mismatch between what the kubelet believes the hostname is
and what we tell kubeadm our hostname is. Just be very explicit about
what the hostname is by way of the --hostname-override kubelet flag.

Signed-off-by: Craig Tracey <craigtracey@gmail.com>