### PR TITLE
Tweak some settings for better Prometheus metrics access.

### DIFF
--- a/scripts/setup-kubelet-hostname.sh
+++ b/scripts/setup-kubelet-hostname.sh
@@ -5,8 +5,10 @@ HOSTNAME="$(hostname -f)"
 
 # Setting --hostname-override is a workaround for https://github.com/kubernetes/kubeadm/issues/653
 # Setting --cloud-provider is a workaround for https://github.com/kubernetes/kubeadm/issues/620
+# Setting --authentication-token-webhook allows authenticated Prometheus access to the Kubelet metrics endpoint
+# (see https://github.com/coreos/prometheus-operator/blob/master/contrib/kube-prometheus/docs/kube-prometheus-on-kubeadm.md)
 /bin/cat > /etc/systemd/system/kubelet.service.d/10-hostname.conf <<EOF
 [Service]
-Environment="KUBELET_EXTRA_ARGS= --hostname-override=${HOSTNAME} --cloud-provider=aws"
+Environment="KUBELET_EXTRA_ARGS= --hostname-override=${HOSTNAME} --cloud-provider=aws --authentication-token-webhook=true"
 EOF
 systemctl daemon-reload


### PR DESCRIPTION
These are essentially the changes documented in [kube-prometheus-on-kubeadm.md](https://github.com/coreos/prometheus-operator/blob/master/contrib/kube-prometheus/docs/kube-prometheus-on-kubeadm.md). They enable Prometheus running in Kubernetes to scrape container-level metrics from each Kubelet (authenticating with a ServiceAccount token) ~and to scrape metrics from `kube-controller-manager` and `kube-scheduler` (anonymously)~.

~These have some tradeoffs that we should discuss. The `kube-controller-manager` and `kube-scheduler` `--address` changes mean that they will expose metrics over these endpoints to the whole cluster.~

~These metrics aren't super sensitive but they do give away some context about where the cluster is running, the versions of the components, and some high level picture of what's running in the cluster. I think this is acceptable for most use cases where the Quick Start is appropriate today.~

~There is recent work upstream (https://github.com/kubernetes/kubernetes/pull/59582) that will add authentication options for these endpoints.~

#### Update
I dropped the `--address` changes and left only the Kubelet authentication flag change.