### PR TITLE
Fix CoreDNS test typo

### DIFF
--- a/scripts/setup-k8s-master.sh.in
+++ b/scripts/setup-k8s-master.sh.in
@@ -57,8 +57,8 @@ EOF
 
 # Feature gates
 echo "featureGates:" >> /tmp/kubeadm.yaml
-if [[ "{{ClusterDNSProvider}}" == "coredns" ]]; then
-  echo "  CoreDNS = True" >> /tmp/kubeadm.yaml
+if [[ "{{ClusterDNSProvider}}" == "CoreDNS" ]]; then
+  echo "  CoreDNS: True" >> /tmp/kubeadm.yaml
 fi
 
 if [[ "{{NetworkingProvider}}" == "calico" ]]; then


### PR DESCRIPTION
Resolves: https://github.com/heptio/aws-quickstart/issues/162

The CoreDNS setting was not taking effect due to a test that was failing for incorrect case.