### PR TITLE
Use config file to register node and provide kubelet flags

### DIFF
--- a/scripts/setup-k8s-node.sh.in
+++ b/scripts/setup-k8s-node.sh.in
@@ -30,8 +30,18 @@ kubeadm reset --force
 # Get the discovery file
 aws s3 cp "s3://{{ClusterInfoBucket}}/cluster-info.yaml" /tmp/cluster-info.yaml
 
-kubeadm join \
-    --node-name="$(hostname -f 2>/dev/null || curl http://169.254.169.254/latest/meta-data/local-hostname)" \
-    --token="{{ClusterToken}}" \
-    --discovery-file="/tmp/cluster-info.yaml" \
-    "{{K8sMasterPrivateIp}}:6443"
+HOSTNAME="$(hostname -f 2>/dev/null || curl http://169.254.169.254/latest/meta-data/local-hostname)"
+
+cat >/tmp/kubeadm-node.yaml <<EOF
+---
+apiVersion: kubeadm.k8s.io/v1alpha2
+kind: NodeConfiguration
+token: {{ClusterToken}}
+discoveryFile: /tmp/cluster-info.yaml
+nodeRegistration:
+  name: ${HOSTNAME}
+  kubeletExtraArgs:
+    cloud-provider: aws
+EOF
+
+kubeadm join --config /tmp/kubeadm-node.yaml "{{K8sMasterPrivateIp}}:6443"


### PR DESCRIPTION
Fixes #214 
Signed-off-by: Vince Prignano <vince@vincepri.com>

This PR fixes the node registration using v1alpha2 NodeConfiguration. I spun up a full quickstart on AWS and was able to reproduce @stevesloka issue by running `kubectl run nginx --image=nginx` and `kubectl expose deployment nginx --port=80 --type=LoadBalancer`.

Kubelet logs showed `No cloud provider specified`, even though the --cloud-provider=aws flag was being set in the extra args with systemd, as shown below:

```
root@ip-10-0-31-162:/home/ubuntu# systemctl cat kubelet
# /lib/systemd/system/kubelet.service
[Unit]
Description=kubelet: The Kubernetes Node Agent
Documentation=https://kubernetes.io/docs/home/

[Service]
ExecStart=/usr/bin/kubelet
Restart=always
StartLimitInterval=0
RestartSec=10

[Install]
WantedBy=multi-user.target

# /etc/systemd/system/kubelet.service.d/10-hostname.conf
[Service]
Environment="KUBELET_EXTRA_ARGS= --hostname-override=ip-10-0-31-162.ec2.internal --cloud-provider=aws --authentication-token-webhook=true"
# /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
# Note: This dropin only works with kubeadm and kubelet v1.11+
[Service]
Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
Environment="KUBELET_CONFIG_ARGS=--config=/var/lib/kubelet/config.yaml"
# This is a file that "kubeadm init" and "kubeadm join" generates at runtime, populating the KUBELET_KUBEADM_ARGS variable dynamically
EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
# This is a file that the user can use for overrides of the kubelet args as a last resort. Preferably, the user should use
# the .NodeRegistration.KubeletExtraArgs object in the configuration files instead. KUBELET_EXTRA_ARGS should be sourced from this file.
EnvironmentFile=-/etc/default/kubelet
ExecStart=
ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS $KUBELET_EXTRA_ARGS
```

Which produces this runtime service:
```
● kubelet.service - kubelet: The Kubernetes Node Agent
   Loaded: loaded (/lib/systemd/system/kubelet.service; enabled; vendor preset: enabled)
  Drop-In: /etc/systemd/system/kubelet.service.d
           └─10-hostname.conf, 10-kubeadm.conf
   Active: active (running) since Wed 2018-09-19 16:41:15 UTC; 11min ago
     Docs: https://kubernetes.io/docs/home/
 Main PID: 3043 (kubelet)
    Tasks: 15
   Memory: 50.8M
      CPU: 10.308s
   CGroup: /system.slice/kubelet.service
           └─3043 /usr/bin/kubelet --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --config=/var/lib/kubelet/config.yaml --cgroup-driver=systemd --cni-bin-dir=/opt/cni/bin --cni-conf-dir=/etc/cni/net.d --hostname-override=ip-10-0-31-162.ec2.internal --network-plugin=cni
```

After applying the changes in this PR, the runtime service looks better:
```
● kubelet.service - kubelet: The Kubernetes Node Agent
   Loaded: loaded (/lib/systemd/system/kubelet.service; enabled; vendor preset: enabled)
  Drop-In: /etc/systemd/system/kubelet.service.d
           └─10-hostname.conf, 10-kubeadm.conf
   Active: active (running) since Wed 2018-09-19 16:09:20 UTC; 45min ago
     Docs: https://kubernetes.io/docs/home/
 Main PID: 2989 (kubelet)
    Tasks: 16
   Memory: 54.0M
      CPU: 36.578s
   CGroup: /system.slice/kubelet.service
           └─2989 /usr/bin/kubelet --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --config=/var/lib/kubelet/config.yaml --cloud-provider=aws --cgroup-driver=systemd --cni-bin-dir=/opt/cni/bin --cni-conf-dir=/etc/cni/net.d --hostname-override=ip-10-0-18-33.ec2.internal --network-plugin=cni
```