### PR TITLE
Set allocate-node-cidrs to false

### DIFF
--- a/scripts/setup-k8s-master.sh.in
+++ b/scripts/setup-k8s-master.sh.in
@@ -78,6 +78,7 @@ bootstrapTokens:
   - authentication
 controllerManagerExtraArgs:
   cloud-provider: aws
+  allocate-node-cidrs: "false"
 EOF
 
 # Feature gates


### PR DESCRIPTION
This commits fixes an error in the k8s controller manager that showed “Couldn't reconcile node routes: error listing routes: unable to find route table for AWS cluster” when controller manager is started with --cloud-provider=aws.

Signed-off-by: Vince Prignano <vince@vincepri.com>

Fixes #214 