### PR TITLE
Refresh for v1.13

### DIFF
--- a/scripts/setup-k8s-master.sh.in
+++ b/scripts/setup-k8s-master.sh.in
@@ -55,19 +55,8 @@ kubeadm reset --force
 
 cat >/tmp/kubeadm.yaml <<EOF
 ---
-apiVersion: kubeadm.k8s.io/v1alpha2
-kind: MasterConfiguration
-kubernetesVersion: "$(cat /etc/kubernetes_community_ami_version)"
-api:
-  controlPlaneEndpoint: "${LB_DNS}:443"
-apiServerCertSANs:
-- "${LB_IPV4}"
-apiServerExtraArgs:
-  cloud-provider: "aws"
-nodeRegistration:
-  name: "${HOSTNAME}"
-  kubeletExtraArgs:
-    cloud-provider: "aws"
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: InitConfiguration
 bootstrapTokens:
 - groups:
   - "system:bootstrappers:kubeadm:default-node-token"
@@ -76,15 +65,34 @@ bootstrapTokens:
   usages:
   - signing
   - authentication
-controllerManagerExtraArgs:
-  cloud-provider: "aws"
-  allocate-node-cidrs: "false"
+nodeRegistration:
+  name: "${HOSTNAME}"
+  kubeletExtraArgs:
+    cloud-provider: "aws"
+---
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: ClusterConfiguration
+kubernetesVersion: "$(cat /etc/kubernetes_community_ami_version)"
+apiServer:
+  timeoutForControlPlane: 4m0s
+  certSANs:
+  - "${LB_IPV4}"
+  extraArgs:
+    cloud-provider: "aws"
+clusterName: kubernetes
+controlPlaneEndpoint: "${LB_DNS}:443"
+controllerManager:
+  extraArgs:
+    cloud-provider: "aws"
+    allocate-node-cidrs: "false"
 EOF
 
 # Feature gates
-echo "featureGates:" >> /tmp/kubeadm.yaml
+echo "dns:" >> /tmp/kubeadm.yaml
 if [[ "{{ClusterDNSProvider}}" == "CoreDNS" ]]; then
-  echo "  CoreDNS: True" >> /tmp/kubeadm.yaml
+  echo "  type: CoreDNS" >> /tmp/kubeadm.yaml
+else
+  echo "  type: kube-dns" >> /tmp/kubeadm.yaml
 fi
 
 if [[ "{{NetworkingProvider}}" == "calico" ]]; then
@@ -120,11 +128,12 @@ kubectl apply -f {{NetworkPolicyUrl}}
 
 # Use kubeadm's kubeconfig command to grab a client-cert-authenticated
 # kubeconfig file for administrative access to the cluster.
-# Because kubeadm doesn't set controlPlaneEndpoint as master, the
-# --apiserver-advertise-address is set to the load balancer external ipv4 address.
 KUBECONFIG_OUTPUT=/home/ubuntu/kubeconfig
 
-kubeadm alpha phase kubeconfig user \
+# kubeadm kubeconfig will select the host's default interface as the
+# controlPlaneEndpoint. Since that is a private interface we need to manually
+# override it to the load balancer's DNS.
+kubeadm alpha kubeconfig user \
   --client-name admin \
   --apiserver-advertise-address "${LB_IPV4}" \
   >$KUBECONFIG_OUTPUT

--- a/scripts/setup-k8s-node.sh.in
+++ b/scripts/setup-k8s-node.sh.in
@@ -34,10 +34,12 @@ HOSTNAME="$(hostname -f 2>/dev/null || curl http://169.254.169.254/latest/meta-d
 
 cat >/tmp/kubeadm-node.yaml <<EOF
 ---
-apiVersion: kubeadm.k8s.io/v1alpha2
-kind: NodeConfiguration
-token: "{{ClusterToken}}"
-discoveryFile: "/tmp/cluster-info.yaml"
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: JoinConfiguration
+discovery:
+  tlsBootstrapToken: "{{ClusterToken}}"
+  file:
+    kubeConfigPath: "/tmp/cluster-info.yaml"
 nodeRegistration:
   name: "${HOSTNAME}"
   kubeletExtraArgs:

--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -366,35 +366,37 @@ Mappings:
   # http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html
   RegionMap:
     ap-northeast-1:
-      '64': ami-0287de46d98c42343
+      '64': ami-01a3c447951e4a730
     ap-northeast-2:
-      '64': ami-00632365e06755f77
+      '64': ami-046c68921ae08d582
     ap-south-1:
-      '64': ami-0f47cbff3b4628ecf
+      '64': ami-0decd838bb43ff88a
     ap-southeast-1:
-      '64': ami-065fb8691329f87f6
+      '64': ami-08cf069e7776615af
     ap-southeast-2:
-      '64': ami-0b99ac46d7c89d11e
+      '64': ami-0cbf7a4d1e7cb7407
     ca-central-1:
-      '64': ami-02cd396e79243d9d2
+      '64': ami-0a038e67915f928f4
     eu-central-1:
-      '64': ami-0e23b1905d251df27
+      '64': ami-09d7b87b7558e9346
+    eu-north-1:
+      '64': ami-0580ceeaffa40e6e9
     eu-west-1:
-      '64': ami-0f671b8dabac777e4
+      '64': ami-08b24c07d4426e14d
     eu-west-2:
-      '64': ami-02008fa81d12a91ea
+      '64': ami-0521c4dc863d418da
     eu-west-3:
-      '64': ami-03a8da0a37befd852
+      '64': ami-032c8dff9a658a260
     sa-east-1:
-      '64': ami-0910783990cf762a5
-    us-east-1:
-      '64': ami-0a8d2e67ae34f3009
+      '64': ami-0c340e60b0336c0c6
     us-east-2:
-      '64': ami-03482947ae9c290df
+      '64': ami-036a034cc552b82e8
     us-west-1:
-      '64': ami-0c29878cfd586c4f4
+      '64': ami-0ece97a717eed7f2d
     us-west-2:
-      '64': ami-0f8129dfa51fb22c5
+      '64': ami-0ef77d0b02cb5e409
+    us-east-1:
+      '64': ami-0d4f0ff8fb87a039c
 # Helper Conditions which help find the right values for resources
 Conditions:
   AssociationProvidedCondition:

--- a/wardroom.json
+++ b/wardroom.json
@@ -1,10 +1,10 @@
 {
     "ami": {
-        "build_version": "91163cee43139fc3633180b7db607c505fcbbef6",
+        "build_version": "0507eb26b9ae45e5f44a40cb01b2f1b24b0badf6",
         "distribution": "Ubuntu",
-        "distribution_release": "xenial",
-        "distribution_version": "16.04",
+        "distribution_release": "bionic",
+        "distribution_version": "18.04",
         "kubernetes_cni_version": "0.6.0-00",
-        "kubernetes_version": "1.11.5-00"
+        "kubernetes_version": "1.13.2-00"
     }
 }


### PR DESCRIPTION
Updates include:
 - Underlying images are based on Ubuntu 18.04
 - Docker version updated
 - kubeadm config API types moved from v1alpha2 to v1beta1

Signed-off-by: John Schnake <jschnake@vmware.com>