### PR TITLE
Adjust security group to always communicate with the NAT EIP

### DIFF
--- a/templates/kubernetes-cluster-with-new-vpc.template
+++ b/templates/kubernetes-cluster-with-new-vpc.template
@@ -705,6 +705,7 @@ Resources:
       TemplateURL: !Sub "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}templates/kubernetes-cluster.template"
       Parameters:
         VPCID: !Ref VPC
+        NATEIP: !Ref NATEIP
         AvailabilityZone: !Ref AvailabilityZone
         InstanceType: !Ref InstanceType
         DiskSizeGb: !Ref DiskSizeGb

--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -36,6 +36,7 @@ Metadata:
         default: Amazon EC2 Configuration
       Parameters:
       - VPCID
+      - NATEIP
       - AvailabilityZone
       - InstanceType
       - DiskSizeGb
@@ -66,6 +67,8 @@ Metadata:
         default: SSH Key
       VPCID:
         default: VPC
+      NATEIP:
+        default: NAT Elastic IP of the private subnet
       AvailabilityZone:
         default: Availability Zone
       ClusterSubnetId:
@@ -108,6 +111,12 @@ Parameters:
   VPCID:
     Description: Existing VPC to use for this cluster.
     Type: AWS::EC2::VPC::Id
+
+  NATEIP:
+    Description: NAT Elastic IP of the private subnet
+    Type: String
+    AllowedPattern: "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})"
+    ConstraintDescription: must be a valid IPv4 address of the form x.x.x.x.
 
   ClusterSubnetId:
     Description: Existing subnet to use for this cluster. Must belong to the Availability Zone above.
@@ -1073,6 +1082,14 @@ Resources:
         ToPort: 443
         IpProtocol: tcp
       - CidrIp: !Ref ApiLbLocation
+        FromPort: 6443
+        ToPort: 6443
+        IpProtocol: tcp
+      - CidrIp: !Sub "${NATEIP}/32"
+        FromPort: 443
+        ToPort: 443
+        IpProtocol: tcp
+      - CidrIp: !Sub "${NATEIP}/32"
         FromPort: 6443
         ToPort: 6443
         IpProtocol: tcp


### PR DESCRIPTION
If the user specifies an admin ingress location then the
security group for the LB prevents communication with the
NAT of the private subnet breaking the cluster. It should
always permit communication to the Elastic IP of the NAT
gateway.

Fixes #225