### PR TITLE
Default instance type to m5.large

### DIFF
--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -144,7 +144,7 @@ Parameters:
   InstanceType:
     Description: EC2 instance type for the cluster.
     Type: String
-    Default: m4.large
+    Default: m5.large
     AllowedValues:
     - c4.2xlarge
     - c4.4xlarge


### PR DESCRIPTION
m5 should be cheaper in all regions and offers better performance as well.