### PR TITLE
Branding changes from Heptio to VMware

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 ![AWS Quick Start for Kubernets](images/banner.jpg)
 
-# Heptio AWS Quickstart
+# VMware AWS Quickstart
 
 [<img
 src="https://raw.githubusercontent.com/cncf/artwork/master/kubernetes/certified-kubernetes/1.11/color/certified-kubernetes-1.11-color.png"
 align="right" width="200px" alt="certified kubernetes 1.11">][certified] These
-are the CloudFormation templates for the Heptio AWS Quick Start.  This is where
+are the CloudFormation templates for the VMware AWS Quick Start.  This is where
 active development is happening.
 
 Details of the Quick Start are in this [Heptio Blog post][details].
@@ -13,21 +13,21 @@ Details of the Quick Start are in this [Heptio Blog post][details].
 Amazon's page for this is [here][amazon].
 
 This will be updated and pushed regularly to
-https://github.com/aws-quickstart/quickstart-heptio.
+https://github.com/aws-quickstart/quickstart-vmware.
 
 [certified]: https://github.com/cncf/k8s-conformance/tree/master/v1.10/heptio
 [details]: https://blog.heptio.com/aws-quickstart-for-kubernetes-26ccaf7e1c8f#.aqb0bit5l
-[amazon]: https://aws.amazon.com/quickstart/architecture/heptio-kubernetes/
+[amazon]: https://aws.amazon.com/quickstart/architecture/vmware-kubernetes/
 
 ## Deploying the latest release
 
 The canonical way to deploy this Quick Start is by following the "Deploy on AWS
 into a new VPC" link on this project's [AWS Quick Start Page][qs-arch].
 
-[qs-arch]: https://aws.amazon.com/quickstart/architecture/heptio-kubernetes/
+[qs-arch]: https://aws.amazon.com/quickstart/architecture/vmware-kubernetes/
 
-You can see what's behind that link by checking AWS's fork of Heptio's
-repository at https://github.com/aws-quickstart/quickstart-heptio.  The `master`
+You can see what's behind that link by checking AWS's fork of VMware's
+repository at https://github.com/aws-quickstart/quickstart-vmware.  The `master`
 branch of github.com/heptio/aws-quickstart is merged into AWS's repository and
 deployed to the Quick Start page on a monthly basis.
 
@@ -45,7 +45,7 @@ Quick Start page using the AWS Console.
 
 **[Launch Latest Quickstart Now][launch]**
 
-[launch]: https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?param_QSS3BucketName=heptio-aws-quickstart-test&param_QSS3KeyPrefix=heptio%2Fkubernetes%2Fmaster%2F&stackName=Heptio-Kubernetes&templateURL=https:%2F%2Fheptio-aws-quickstart-test.s3.amazonaws.com%2Fheptio%2Fkubernetes%2Fmaster%2Ftemplates%2Fkubernetes-cluster-with-new-vpc.template
+[launch]: https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?param_QSS3BucketName=vmware-aws-quickstart-test&param_QSS3KeyPrefix=vmware%2Fkubernetes%2Fmaster%2F&stackName=VMware-Kubernetes&templateURL=https:%2F%2Fvmware-aws-quickstart-test.s3.amazonaws.com%2Fvmware%2Fkubernetes%2Fmaster%2Ftemplates%2Fkubernetes-cluster-with-new-vpc.template
 
 ### Master branch from the command line
 
@@ -114,7 +114,7 @@ kubectl get nodes
 This Quick Start is developed as a set of AWS CloudFormation templates. This is
 a brief overview of the files in this repo, for more architecture details see
 the [Deployment
-Guide](https://s3.amazonaws.com/quickstart-reference/heptio/latest/doc/heptio-kubernetes-on-the-aws-cloud.pdf)
+Guide](https://s3.amazonaws.com/quickstart-reference/vmware/latest/doc/vmware-kubernetes-on-the-aws-cloud.pdf)
 
 **The `templates` directory**:
 

--- a/bin/boot-cloud-from-local.sh
+++ b/bin/boot-cloud-from-local.sh
@@ -9,8 +9,8 @@ AVAILABILITY_ZONE="${AVAILABILITY_ZONE:-us-west-2a}"
 
 # Bucket may exist.
 # Can create a bucket with something like:
-# aws s3api create-bucket --bucket heptio-hello-world-idjfuiewhj --create-bucket-configuration LocationConstraint=us-west-2
-S3_BUCKET="${S3_BUCKET:-quickstart-heptio-com}"
+# aws s3api create-bucket --bucket vmware-hello-world-idjfuiewhj --create-bucket-configuration LocationConstraint=us-west-2
+S3_BUCKET="${S3_BUCKET:-quickstart-vmware-com}"
 
 # Will error if the bucket doesn't exist or you don't have permission to it.
 aws s3api head-bucket --bucket "${S3_BUCKET}"

--- a/bin/boot-latest-published.sh
+++ b/bin/boot-latest-published.sh
@@ -5,7 +5,7 @@ REGION=us-west-2
 AZ=us-west-2b
 
 # What to name your CloudFormation stack
-STACK=Heptio-Kubernetes
+STACK=VMware-Kubernetes
 
 # Which SSH key you want to allow access to the cluster
 KEYNAME=laptop
@@ -19,7 +19,7 @@ INGRESS=0.0.0.0/0
 aws cloudformation create-stack \
   --region $REGION \
   --stack-name $STACK \
-  --template-url "https://s3.amazonaws.com/quickstart-reference/heptio/latest/templates/kubernetes-cluster-with-new-vpc.template" \
+  --template-url "https://s3.amazonaws.com/quickstart-reference/vmware/latest/templates/kubernetes-cluster-with-new-vpc.template" \
   --parameters \
     ParameterKey=AvailabilityZone,ParameterValue=$AZ \
     ParameterKey=KeyName,ParameterValue=$KEYNAME \

--- a/bin/boot-master-branch.sh
+++ b/bin/boot-master-branch.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 
-# This is where Heptio stores templates/scripts for the master branch of this repository
-S3_BUCKET=heptio-aws-quickstart-test
-S3_PREFIX=heptio/kubernetes/master/
+# This is where VMware stores templates/scripts for the master branch of this repository
+S3_BUCKET=vmware-aws-quickstart-test
+S3_PREFIX=vmware/kubernetes/master/
 
 # Where to place your cluster
 REGION=us-west-2
 AZ=us-west-2b
 
 # What to name your CloudFormation stack
-STACK=Heptio-Kubernetes
+STACK=VMware-Kubernetes
 
 # What SSH key you want to allow access to the cluster (must be created ahead of time in your AWS EC2 account)
 KEYNAME=mykey

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,3 +1,3 @@
-This directory contains CI scripts and configuration that are used by both heptio's CI tools (for development work) and by Amazon's CI tools (for testing before the templates are written to the official `quickstart-examples` s3 bucket.)
+This directory contains CI scripts and configuration that are used by both VMware's CI tools (for development work) and by Amazon's CI tools (for testing before the templates are written to the official `quickstart-examples` s3 bucket.)
 
-config.yml is needed by Amazon's CI (for the https://github.com/aws-quickstart/quickstart-heptio repo), the rest of the files are used by heptio's CI directly (for the https://github.com/heptio/aws-quickstart repo.)
+config.yml is needed by Amazon's CI (for the https://github.com/aws-quickstart/quickstart-vmware repo), the rest of the files are used by VMware's CI directly (for the https://github.com/heptio/aws-quickstart repo.)

--- a/ci/all-docker.sh
+++ b/ci/all-docker.sh
@@ -31,7 +31,7 @@ if [[ -z "${STACK_NAME}" ]]; then
 fi
 AZ="${AZ:-us-west-2c}"
 REGION="${REGION:-us-west-2}"
-S3_BUCKET="${S3_BUCKET:-"heptio-ci-aws-quickstart"}"
+S3_BUCKET="${S3_BUCKET:-"vmware-ci-aws-quickstart"}"
 S3_PREFIX="${S3_PREFIX:-${STACK_NAME}/}"
 
 # Build the docker image

--- a/ci/config.yml
+++ b/ci/config.yml
@@ -1,7 +1,7 @@
 global:
   marketplace-ami: false
   owner: quickstart-eng@amazon.com
-  qsname: quickstart-heptio
+  qsname: quickstart-vmware
   reporting: true
   regions:
     - ap-northeast-1
@@ -16,6 +16,6 @@ global:
     - us-west-2
 
 tests:
-  heptio:
+  vmware:
     parameter_input: kubernetes-cluster-with-new-vpc-inputs.json
     template_file: kubernetes-cluster-with-new-vpc.template

--- a/ci/taskcat.yml
+++ b/ci/taskcat.yml
@@ -1,7 +1,7 @@
 global:
   marketplace-ami: false
   owner: quickstart-eng@amazon.com
-  qsname: quickstart-heptio
+  qsname: quickstart-vmware
   reporting: true
   regions:
     - ap-northeast-1
@@ -16,6 +16,6 @@ global:
     - us-west-2
 
 tests:
-  heptio:
+  vmware:
     parameter_input: kubernetes-cluster-with-new-vpc-inputs.json
     template_file: kubernetes-cluster-with-new-vpc.template

--- a/ci/tests/e2e.sh
+++ b/ci/tests/e2e.sh
@@ -140,6 +140,9 @@ while :; do
   if [[ $tries -gt 30 ]]; then # 5 minutes-ish
     echo "Sonobuoy did not finish after 5 minutes.  Master logs:"
     kubectl logs sonobuoy
+    echo "Sonobuoy status and logs:"
+    sonobuoy status
+    sonobuoy logs
     exit $ERRCODE_TIMEOUT
   fi
 done

--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -1,0 +1,51 @@
+# Welcome to the Next Steps for your Kubernetes cluster.
+
+This guide is for [Kubernetes Quick Start](https://aws.amazon.com/quickstart/) admins and users. This guide assumes you have deployed the Kubernetes Quick Start by walking through [Amazon’s Quick Start PDF](https://s3.amazonaws.com/quickstart-reference/vmware/latest/doc/vmware-kubernetes-on-the-aws-cloud.pdf), which uses Amazon’s CloudFormation console.
+
+Now that you have your Kubernetes stack on Amazon, we recommend setting up [WordPress with Helm](tutorial-wordpress.md) as a demo application to explore your new cluster.
+
+
+> Note:
+>
+>This stack is appropriate for proof of concept (PoC), experimentation, development, and small internal-facing projects. Consider this a test drive.
+>
+>This stack does not currently support upgrades and must be rebuilt for new versions.
+
+
+## Release notes
+Release notes: AWS Quick Start for Kubernetes by VMware
+
+The Quick Start builds Kubernetes 1.13.2.
+
+## Next steps
+If you’ve completed the Kubernetes Quick Start on AWS, we recommend that you try these next steps:
+
+ - Check that your cluster is configured and working as expected by running [Sonobuoy](https://github.com/heptio/sonobuoy) against your cluster. Sonobuoy provides cluster diagnostics by running Kubernetes conformance tests.
+ - Explore your cluster and deploy a demo application: [WordPress with Helm](tutorial-wordpress.md)
+ - Allow traffic: [Allow outside traffic to your cluster with load balancing](tutorial-traffic.md)
+
+## Additional resources
+ VMware has collected some links to help you explore your Kubernetes cluster:
+
+- Bitnami shows how to deploy a MEAN stack: [Deploy, Scale And Upgrade An Application On Kubernetes With Helm](https://docs.bitnami.com/kubernetes/how-to/deploy-application-kubernetes-helm/)
+ - Bitnami manages a library of [Kubernetes-ready applications](https://kubeapps.com/)
+ - Project Calico goes into detail on networking for Kubernetes: [Calico for Kubernetes](https://docs.projectcalico.org/v3.5/getting-started/kubernetes/)
+
+## Architecture and decisions
+This CloudFormation template [(download)](https://s3.amazonaws.com/quickstart-reference/vmware/latest/templates/kubernetes-cluster-with-new-vpc.template) [(launch)](https://console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/new?stackName=k8s&templateURL=https://s3.amazonaws.com/quickstart-reference/vmware/latest/templates/kubernetes-cluster-with-new-vpc.template) creates two stacks: one that builds a wrapper virtual private cloud (VPC), and one that deploys the Kubernetes cluster into it. For advanced AWS users, you can [deploy just the Kubernetes stack](https://console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/new?stackName=k8s&templateURL=https://s3.amazonaws.com/quickstart-reference/vmware/latest/templates/kubernetes-cluster.template) into your existing AWS architecture. This architecture list is for the template that creates a new VPC for your Kubernetes cluster.
+
+The Quick Start builds Kubernetes 1.13.2.
+
+ - A VPC in a single Availability Zone
+ - 2 subnets, one public and one private
+ - 1 EC2 instance acting as a bastion host in the public subnet
+ - 1 EC2 instance with automatic recovery for the master node in the private subnet
+ - 1-20 EC2 instances in an Auto Scaling Group for additional nodes in the private subnet (2 with default settings)
+ - 1 ELB load balancer for HTTPS access to the Kubernetes API
+ - Ubuntu 18.04 LTS for all nodes; the [base image](https://github.com/heptio/aws-quickstart/tree/master/packer) is a [custom AMI](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) based on Ubuntu 18.04
+ - 40 GiB of disk for the EC2 instances
+ - [kubeadm](http://kubernetes.io/docs/getting-started-guides/kubeadm/) for bootstrapping Kubernetes on Linux
+ - [Docker](https://www.docker.com/) for the container runtime, which Kubernetes depends on
+ - [Calico](https://www.projectcalico.org/calico-networking-for-kubernetes/) or [Weave](https://github.com/weaveworks-experiments/weave-kube) for pod networking
+ - One stack-only security group that allows port 22 for SSH access from the bastion host, port 6443 for HTTPS access to the API, and inter-node connectivity on all ports
+ - The templates are built for [CloudFormation](https://aws.amazon.com/cloudformation/).

--- a/docs/tutorial-traffic.md
+++ b/docs/tutorial-traffic.md
@@ -1,0 +1,154 @@
+# Expose Services on your AWS Quick Start Kubernetes cluster
+
+![../../_images/banner-twitter.jpg][1]
+
+This tutorial explains how to run a basic service on your Kubernetes cluster and expose it to the Internet using Amazon's [Elastic Load Balancing (ELB)][2].
+
+## Prerequisites
+
+This tutorial assumes the following:
+
+* You have a local Linux/Unix environment (like a MacBook)
+* You have successfully created the CloudFormation stacks from the [AWS Kubernetes Quick Start][3] (or followed [the CLI walkthrough][4] if you prefer)
+* You have copied the resulting `kubeconfig` file to your local machine, and can successfully run `kubectl` commands against the cluster (see [Step 4 of the setup guide][5])
+
+Try running `kubectl get nodes`. Your output should look similar to this:
+    
+    
+    NAME               STATUS         AGE
+    ip-10-0-0-0     Ready,master      1h
+    ip-172-172-172-172 Ready          1h
+    ip-192-192-192-192 Ready          1h
+    
+
+If it is, your cluster is ready to go! If the output looks substantially different, try running through the [setup walkthrough][4] again.
+
+## 1\. Deploy a simple demo application
+
+For the example we'll run the [echoheaders][6] app, which is a simple nginx server that prints the headers it receives.
+
+First we create a new namespace under which the application will run:
+    
+    
+    kubectl create namespace simple-demo
+    
+
+Example output:
+    
+    
+    $ kubectl create namespace simple-demo
+    namespace "simple-demo" created
+    
+
+Next we run our application within the namespace, using a single command:
+    
+    
+    kubectl run --namespace simple-demo echoheaders --image=gcr.io/google_containers/echoserver:1.4 --replicas=1 --port=8080
+    
+
+This creates a deployment named `echoheaders` on your cluster, which will run a single replica of the `echoserver` container, listening on port 8080. The deployment will re-launch the container automatically if it ever crashes.
+
+Let's look at what was created in the `simple-demo` namespace after we ran the deployment:
+    
+    
+    $ kubectl run --namespace simple-demo echoheaders --image=gcr.io/google_containers/echoserver:1.4 --replicas=1 --port=8080
+    deployment "echoheaders" created
+    $ kubectl get all --namespace simple-demo
+    NAME                              READY     STATUS    RESTARTS   AGE
+    po/echoheaders-2787888573-c3nt1   1/1       Running   0          11m
+    
+    NAME                 DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
+    deploy/echoheaders   1         1         1            1           11m
+    
+    NAME                        DESIRED   CURRENT   READY     AGE
+    rs/echoheaders-2787888573   1         1         1         11m
+    
+
+We see:
+
+* A single Pod, `po/echoheaders-2787888573-c3nt1`, which runs the echoserver container
+* A single Replica Set, `rs/echoheaders-2787888573`, which manages the Pod and restarts it if it ever fails
+* A single Deployment, `deploy/echoheaders`, which is the object that created the Replica Set. This can be edited to update the application without causing downtime.
+
+## 2\. Expose our application to the Internet
+
+Next we can use `kubectl expose` to create a Service that exposes our new application to the Internet over an AWS Elastic Load Balancer (ELB).
+
+Let's run the following command:
+    
+    
+    kubectl expose --namespace=simple-demo deployment echoheaders --type=LoadBalancer --port=80 --target-port=8080 --name=echoheaders-public
+    
+
+This will create a Service object, which acts as an endpoint for routing to an instance of the `echoheaders` application.
+
+After we expose the deployments, we can inspect the results with `kubectl describe`:
+    
+    
+    $ kubectl --namespace=simple-demo describe service echoheaders-public
+    Name:           echoheaders-public
+    Namespace:      simple-demo
+    Labels:         run=echoheaders
+    Selector:       run=echoheaders
+    Type:           LoadBalancer
+    IP:         10.103.66.255
+    LoadBalancer Ingress:   a9201a1bdfc6411e68fdc06048bde387-495139964.us-west-1.elb.amazonaws.com
+    Port:            80/TCP
+    NodePort:        30031/TCP
+    Endpoints:      192.168.96.196:8080
+    Session Affinity:   None
+    Events:
+      FirstSeen LastSeen    Count   From            SubObjectPath   Type        Reason          Message
+      --------- --------    -----   ----            -------------   --------    ------          -------
+      2m        2m      1   {service-controller }           Normal      CreatingLoadBalancer    Creating load balancer
+      1m        1m      1   {service-controller }           Normal      CreatedLoadBalancer Created load balancer
+    
+
+This describes the `echoheaders-public` service that was just created. Because it is `type=LoadBalancer`, we have a public-facing URL under the `LoadBalancer Ingress` section. We can now browse to the resulting URL and see our application:
+
+![../../_images/echoheaders-screenshot.png][7]
+
+The port for the service is 80, which is the public external port for this service. But the endpoint is on port 8080, which is the port the container itself is listening on.
+
+For more information about Services, see the [Kubernetes User Guide reference for Services][8].
+
+## Reference: The kubectl expose command
+    
+    
+    NAMESPACE=simple-demo
+    RESOURCETYPE=deployment
+    RESOURCENAME=echoheaders
+    SERVICETYPE=LoadBalancer
+    PORT=80
+    TARGETPORT=8080
+    SERVICENAME=echoheaders-public
+    
+    kubectl expose --namespace=$NAMESPACE 
+    $RESOURCETYPE $RESOURCENAME 
+    --type=$SERVICETYPE 
+    --port=$PORT --target-port=$TARGETPORT 
+    --name=$SERVICENAME
+    
+
+Parameter | Description
+--- | ---
+NAMESPACE | Not required. The namespace under which the application was created. Defaults to `default`.
+RESOURCETYPE | Required. The type of underlying Kubernetes resource to expose as a Service. Possible resources include: Pod, Service, ReplicationController, Deployment, ReplicaSet.
+RESOURCENAME | Required. The name of the resource to expose. In this case, it's the name of the Deployment we created.
+SERVICETYPE | Not required. The type of service to expose. Defaults to `ClusterIP`. For a detailed description of Service types, see [Kubernetes Service Types][9].
+PORT | Not required. The port to expose the Service endpoint on. Defaults to the exposed ports of the underlying Kubernetes resource, but a different port can be specified.
+TARGETPORT | Not required. The port that the underlying resource exposes that should be mapped to the Service. Defaults to the exposed port of the resource.
+SERVICENAME | Required. The name to give the Service resource in Kubernetes.
+
+For a full reference on the `kubectl expose` command, see the [Kubernetes Community documentation][10].
+
+[1]: http://docs.heptio.com/_images/banner-twitter.jpg
+[2]: https://aws.amazon.com/elasticloadbalancing/
+[3]: https://s3.amazonaws.com/quickstart-reference/heptio/latest/doc/heptio-kubernetes-on-the-aws-cloud.pdf
+[4]: http://docs.heptio.com/aws-cloudformation-k8s.html
+[5]: http://docs.heptio.com/content/tutorials/aws-cloudformation-k8s.html#optional-download-kubectl-configuration
+[6]: https://github.com/kubernetes/contrib/tree/master/ingress/echoheaders
+[7]: http://docs.heptio.com/_images/echoheaders-screenshot.png
+[8]: https://kubernetes.io/docs/user-guide/services/
+[9]: https://kubernetes.io/docs/user-guide/services/#publishing-services---service-types
+[10]: https://kubernetes.io/docs/user-guide/kubectl/kubectl_expose/

--- a/docs/tutorial-wordpress.md
+++ b/docs/tutorial-wordpress.md
@@ -1,0 +1,216 @@
+# Run WordPress with Helm on Kubernetes
+
+![../../_images/banner-twitter.jpg][1]
+
+This tutorial shows how to run WordPress from your Kubernetes cluster. [WordPress][2] is an open-source CMS and blogging platform that powers many of the internet's websites.
+
+We use the [Helm][3] package manager to install the software. Helm is a tool for managing pre-configured Kubernetes objects. It's an easy way to install popular software on Kubernetes.
+
+Note that you'll be using default settings from both [VMware's AWS Quick Start][4] and Helm, so make sure the security options fit your use case.
+
+Take a look at the [WordPress Helm configuration for Kubernetes][5].
+
+## Prerequisites
+
+This tutorial assumes the following:
+
+* You have a local Linux/Unix environment (like a MacBook)
+* You have successfully created the CloudFormation stacks from the [AWS Kubernetes Quick Start][6] (or followed [the CLI walkthrough][7] if you prefer)
+* You have copied the resulting `kubeconfig` file to your local machine, and can successfully run `kubectl` commands against the cluster (see [Step 4 of the setup guide][8])
+
+Try running `kubectl get nodes`. Your output should look similar to this:
+    
+    
+    NAME               STATUS         AGE
+    ip-10-0-0-0     Ready,master      1h
+    ip-172-172-172-172 Ready          1h
+    ip-192-192-192-192 Ready          1h
+    
+
+If it is, your cluster is ready to go! If the output looks substantially different, try running through the [setup walkthrough][7] again.
+
+## 1\. Install or upgrade Helm locally
+
+On your **local machine**, install Helm, a popular package manager for Kubernetes.
+
+On OS X, we recommend using [Homebrew][9] to install Helm.
+    
+    
+    brew install kubernetes-helm
+    
+
+If you've already installed Helm, it's a good idea to make sure you're on the latest version:
+    
+    
+    brew upgrade kubernetes-helm
+    
+
+Note that the [latest Helm release][10] is often a bit ahead of Homebrew, and may address issues from previous releases.
+
+Check the [Helm website][3] for instructions on installing Helm for other platforms.
+
+## 2\. Initialize Helm and Tiller
+
+On your **local machine**, initialize Helm for your Kubernetes cluster. This will install Tiller (the Helm server-side component) onto the Kubernetes cluster and set up your local configuration. This depends on your `kubeconfig` having the credentials to connect to the Kubernetes cluster, as described in the prerequisites. For more details, see the [Helm documentation][11].
+
+### Install Tiller
+
+Initialize Helm and configure Tiller with this command:
+
+This works with kubectl to connect to your cluster.
+
+Note
+
+If kubectl isn't configured to connect to your cluster, you might see an error like `Error: error installing: Post http://localhost:8080/apis/extensions/v1beta1/namespaces/kube-system/deployments: dial tcp [::1]:8080: getsockopt: connection refused`. Check your prerequisites if you see this error.
+
+You should see output like:
+    
+    
+    $HELM_HOME has been configured at /Users/varMyUser/.helm.
+    
+    Tiller (the helm server side component) has been installed into your Kubernetes Cluster.
+    Happy Helming!
+    
+
+If you've already installed Tiller on your cluster, it's a good idea to make sure you're on the latest version:
+
+Optionally, check your Helm and Tiller versions:
+
+If they're not both the latest, run through the previous steps to update Helm and Tiller.
+
+### Implement Tiller RBAC fix
+
+At the time of writing, the version of Tiller installed with Homebrew has not caught up to the new default permission structure in Kubernetes 1.6+. On the 1.6+ Kubernetes cluster built by the AWS Quick Start, RBAC is turned on by default, and the default service account for each namespace does not have admin access. Read more about the RBAC updates and a general approach to Kubernetes permission fixes in our [RBAC workaround guide][12]. Read more about this specific workaround [on the Helm issue][13].
+
+To give Tiller permission to install and configure resources on our cluster, first we create a new [ServiceAccount][14] named `tiller` in the system-wide `kube-system` [Namespace][15].
+    
+    
+    kubectl create serviceaccount --namespace kube-system tiller
+    
+
+Create a [ClusterRoleBinding][16] with `cluster-admin` access levels for this new service account named `tiller`. Note that these are very broad permissions, because we want Tiller to be able to install and configure a wide variety of cluster resources.
+    
+    
+    kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
+    
+
+Edit the existing Tiller [Deployment][17] named `tiller-deploy`.
+    
+    
+    kubectl edit deploy --namespace kube-system tiller-deploy
+    
+
+This will open the YAML configuration for this deployment in a text editor. Insert the line `serviceAccount: tiller` in the `spec: template: spec` section of the file:
+    
+    
+    ...
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: helm
+          name: tiller
+      strategy:
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 1
+        type: RollingUpdate
+      template:
+        metadata:
+          creationTimestamp: null
+          labels:
+            app: helm
+            name: tiller
+        spec:
+          serviceAccount: tiller
+          containers:
+          - env:
+            - name: TILLER_NAMESPACE
+              value: kube-system
+    ...
+    
+
+Now Tiller is using the new `tiller` service account we just created, which has expanded permissions. You should be able to successfully use Helm to install your software now.
+
+## 3\. Install WordPress
+
+Create a new Kubernetes [Namespace][15] with:
+    
+    
+    kubectl create namespace varmywordpress
+    
+    
+    
+    namespace "varmywordpress" created
+    
+
+This sets up a new namespace in your Kubernetes cluster to contain all the objects for the WordPress site.
+
+Use Helm to install WordPress into your new namespace. This configures [everything WordPress needs to run][5], including:
+    
+    
+    helm install --namespace varmywordpress --name wordpress stable/wordpress
+    
+
+You will see a large amount of output, starting with:
+    
+    
+    NAME:   wordpress
+    LAST DEPLOYED: Mon Feb 27 17:45:42 2017
+    NAMESPACE: varmywordpress
+    STATUS: DEPLOYED
+    ...
+    
+
+Read through the rest of the output at your leisure. It contains instructions for accessing your site, but these may not be 100% compatible with AWS because of how the Kubernetes stack's networking is configured. (With AWS, Kubernetes stores a hostname for the load balancer, not the IP.)
+
+We'll show you how to access your WordPress site in the next step.
+
+## 4\. Connect to your WordPress site
+
+You'll need to wait 2-10 minutes for WordPress to finish provisioning.
+
+One issue at time of writing: the command Helm gives for finding the site's IP address may not work. Instead, use the following command to find the URL to the new WordPress site:
+    
+    
+    echo http://$(kubectl get svc --namespace varmywordpress wordpress-wordpress -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+    
+
+It should be a lengthy auto-generated URL, like:
+    
+    
+    http://xxxxxx.us-west-2.elb.amazonaws.com
+    
+
+It will typically take a few minutes for the new site's DNS to be ready. After this time, you should be able to visit the new site in your browser.
+
+To log in to your WordPress site, use the following credentials:
+
+* Username: **user**
+* Password: this is automatically generated
+
+You can fetch the password with this command:
+    
+    
+    echo Password: $(kubectl get secret --namespace varmywordpress wordpress-wordpress -o jsonpath="{.data.wordpress-password}" | base64 --decode)
+    
+
+Now you can log into the control panel for WordPress and start crafting your WordPress site running on Kubernetes.
+
+[1]: http://docs.heptio.com/_images/banner-twitter.jpg
+[2]: https://wordpress.org/
+[3]: http://helm.sh/
+[4]: http://docs.heptio.com/aws.html
+[5]: https://github.com/kubernetes/charts/tree/master/stable/wordpress
+[6]: https://s3.amazonaws.com/quickstart-reference/heptio/latest/doc/heptio-kubernetes-on-the-aws-cloud.pdf
+[7]: http://docs.heptio.com/aws-cloudformation-k8s.html
+[8]: http://docs.heptio.com/content/tutorials/aws-cloudformation-k8s.html#optional-download-kubectl-configuration
+[9]: https://brew.sh
+[10]: https://github.com/kubernetes/helm/releases
+[11]: https://github.com/kubernetes/helm/blob/master/docs/quickstart.md
+[12]: http://docs.heptio.com/rbac.html
+[13]: https://github.com/kubernetes/helm/issues/2224
+[14]: https://kubernetes.io/docs/admin/service-accounts-admin/
+[15]: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+[16]: https://kubernetes.io/docs/admin/authorization/rbac/#rolebinding-and-clusterrolebinding
+[17]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/

--- a/templates/kubernetes-cluster-with-new-vpc.template
+++ b/templates/kubernetes-cluster-with-new-vpc.template
@@ -24,8 +24,8 @@ Description: 'QS(5042) Kubernetes AWS CloudFormation Template: Create a Kubernet
   suitable for development and small single-team clusters. **WARNING** This
   template creates four Amazon EC2 instances with default settings. You will
   be billed for the AWS resources used if you create a stack from this template.
-  **SUPPORT** Please visit http://jump.heptio.com/aws-qs-help for support.
-  **NEXT STEPS** Please visit http://jump.heptio.com/aws-qs-next.'
+  **SUPPORT** Please visit https://github.com/heptio/aws-quickstart/blob/master/troubleshooting.md for support.
+  **NEXT STEPS** Please visit https://github.com/heptio/aws-quickstart/blob/master/docs/next-steps.md.'
 
 # The Metadata tells AWS how to display the parameters during stack creation
 Metadata:
@@ -399,7 +399,7 @@ Parameters:
     ConstraintDescription: must be a valid Current Generation EC2 instance type.
 
   AvailabilityZone:
-    Description: The Availability Zone for this cluster. Heptio recommends
+    Description: The Availability Zone for this cluster. VMware recommends
       that you run one cluster per AZ and use tooling to coordinate across AZs.
     Type: AWS::EC2::AvailabilityZone::Name
     ConstraintDescription: must be the name of an AWS Availability Zone
@@ -441,7 +441,7 @@ Parameters:
     AllowedPattern: ^[0-9a-zA-Z-/]*$
     ConstraintDescription: Quick Start key prefix can include numbers, lowercase
       letters, uppercase letters, hyphens (-), and forward slash (/).
-    Default: quickstart-heptio/
+    Default: quickstart-vmware/
     Description: Only change this if you have set up assets in an S3 bucket, as explained
       in the S3 Bucket parameter. S3 key prefix for the Quick Start assets.
       Quick Start key prefix can include numbers, lowercase letters, uppercase
@@ -779,5 +779,5 @@ Outputs:
 
   NextSteps:
     Description: Verify your cluster and deploy a test application. Instructions -
-      http://jump.heptio.com/aws-qs-next
+      https://github.com/heptio/aws-quickstart/blob/master/docs/next-steps.md
     Value: !GetAtt K8sStack.Outputs.NextSteps

--- a/templates/kubernetes-cluster.template
+++ b/templates/kubernetes-cluster.template
@@ -17,16 +17,15 @@ AWSTemplateFormatVersion: '2010-09-09'
 Description: 'QS(5042) Kubernetes AWS CloudFormation Template: Create a Kubernetes
   cluster in an existing VPC. This template is for users who want to add
   a Kubernetes cluster to existing AWS infrastructure. The master node is
-  an auto-recovering Amazon EC2 instance. 1-20 additional EC2 instances in an
-  AutoScalingGroup join the Kubernetes cluster as nodes. An ELB provides
-  configurable external access to the Kubernetes API. If you choose a private
-  subnet, make sure it has a bastion host for SSH access to your cluster. If you
-  choose a public subnet, you can connect directly to the master node. The stack
-  is suitable for development and small single-team clusters. **WARNING** This
-  template creates four Amazon EC2 instances with default settings. You will
-  be billed for the AWS resources used if you create a stack from this template.
-  **SUPPORT** Please visit http://jump.heptio.com/aws-qs-help for support.
-  **NEXT STEPS** Please visit http://jump.heptio.com/aws-qs-next.'
+  an auto-recovering Amazon EC2 instance with additional EC2 instances in an
+  AutoScalingGroup as nodes. An ELB provides configurable external access to the
+  Kubernetes API. If you choose a private subnet, make sure it has a bastion host
+  for SSH access to your cluster. If you choose a public subnet, you can connect
+  directly to the master node. The stack is suitable for development and small
+  single-team clusters. **WARNING** This template creates four Amazon EC2 instances
+  with default settings. You will be billed for the AWS resources.
+  **SUPPORT** Please visit https://github.com/heptio/aws-quickstart/blob/master/troubleshooting.md for support.
+  **NEXT STEPS** Please visit https://github.com/heptio/aws-quickstart/blob/master/docs/next-steps.md.'
 
 # The Metadata tells AWS how to display the parameters during stack creation
 Metadata:
@@ -282,7 +281,7 @@ Parameters:
   # Required. This is an availability zone from your region
   # http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html
   AvailabilityZone:
-    Description: The Availability Zone for this cluster. Heptio recommends
+    Description: The Availability Zone for this cluster. VMware recommends
       that you run one cluster per AZ and use tooling to coordinate across AZs.
     Type: AWS::EC2::AvailabilityZone::Name
     ConstraintDescription: must be the name of an AWS Availability Zone
@@ -330,7 +329,7 @@ Parameters:
     Default: aws-quickstart
     Description: Only change this if you have set up assets, like your own networking
       configuration, in an S3 bucket. This and the S3 Key Prefix parameter let you access
-      scripts from the scripts/ and templates/ directories of your own fork of the Heptio
+      scripts from the scripts/ and templates/ directories of your own fork of the VMware
       Quick Start assets, uploaded to S3 and stored at
       ${bucketname}.s3.amazonaws.com/${prefix}/scripts/somefile.txt.S3. The bucket name
       can include numbers, lowercase letters, uppercase letters, and hyphens (-).
@@ -341,7 +340,7 @@ Parameters:
     AllowedPattern: ^[0-9a-zA-Z-/]*$
     ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters, uppercase
       letters, hyphens (-), and forward slash (/).
-    Default: quickstart-heptio/
+    Default: quickstart-vmware/
     Description: Only change this if you have set up assets in an S3 bucket, as explained
       in the S3 Bucket parameter. S3 key prefix for the Quick Start assets.
       Quick Start key prefix can include numbers, lowercase letters, uppercase
@@ -1182,5 +1181,5 @@ Outputs:
 
   NextSteps:
     Description: Verify your cluster and deploy a test application. Instructions -
-      http://jump.heptio.com/aws-qs-next
-    Value: http://jump.heptio.com/aws-qs-next
+      https://github.com/heptio/aws-quickstart/blob/master/docs/next-steps.md
+    Value: https://github.com/heptio/aws-quickstart/blob/master/docs/next-steps.md


### PR DESCRIPTION
Changes branding from Heptio quickstart to VMware quickstart.

Some of the links/items can't/won't be updated such as links
to old blogs, Github repository names, or other Heptio items
not undergoing renaming at this time.

Signed-off-by: John Schnake <jschnake@vmware.com>